### PR TITLE
func: add new parameter -featuretype to run Prophet4J and outputs a J…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ mvn exec:java -Dexec.mainClass=fr.inria.coming.main.ComingMain
  -location <path>                                                     analyse the content in 'path'
  -message <arg>                                                       comming message
  -mode <mineinstance | diff | features>                               the mode of execution of the analysis
+ -featuretype < S4R | P4J >                                           choose the feature analysis type if the mode is feature
  -output <path>                                                       dump the output of the analysis in the given path
  -outputprocessor <classname>                                         output processors for result
  -parameters <arg>                                                    Parameters, divided by :

--- a/src/main/java/fr/inria/coming/changeminer/entity/IRevision.java
+++ b/src/main/java/fr/inria/coming/changeminer/entity/IRevision.java
@@ -14,4 +14,6 @@ public interface IRevision {
 	public List<IRevisionPair> getChildren();
 
 	public String getName();
+	
+	public String getFolder();
 }

--- a/src/main/java/fr/inria/coming/codefeatures/P4JFeatureAnalyzer.java
+++ b/src/main/java/fr/inria/coming/codefeatures/P4JFeatureAnalyzer.java
@@ -1,0 +1,148 @@
+package fr.inria.coming.codefeatures;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.log4j.Logger;
+import org.json.simple.JSONObject;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import fr.inria.coming.changeminer.analyzer.commitAnalyzer.FineGrainDifftAnalyzer;
+import fr.inria.coming.changeminer.entity.IRevision;
+import fr.inria.coming.core.engine.Analyzer;
+import fr.inria.coming.core.entities.AnalysisResult;
+import fr.inria.coming.core.entities.RevisionResult;
+import fr.inria.prophet4j.feature.FeatureCross;
+import fr.inria.prophet4j.feature.extended.ExtendedFeatureCross;
+import fr.inria.prophet4j.feature.original.OriginalFeatureCross;
+import fr.inria.prophet4j.learner.RepairEvaluator;
+import fr.inria.prophet4j.utility.CodeDiffer;
+import fr.inria.prophet4j.utility.Option;
+import fr.inria.prophet4j.utility.Support;
+import fr.inria.prophet4j.utility.Option.FeatureOption;
+import fr.inria.prophet4j.utility.Option.RankingOption;
+import fr.inria.prophet4j.utility.Structure.FeatureMatrix;
+import fr.inria.prophet4j.utility.Structure.FeatureVector;
+import fr.inria.prophet4j.utility.Structure.ParameterVector;
+
+/**
+ *
+ * @author He Ye
+ *
+ */
+public class P4JFeatureAnalyzer implements Analyzer<IRevision> {
+
+	protected static Logger log = Logger.getLogger(Thread.currentThread().getName());
+
+	protected CodeFeatureDetector cresolver = new CodeFeatureDetector();
+
+	@Override
+	public AnalysisResult analyze(IRevision revision, RevisionResult previousResults) {
+
+		AnalysisResult resultFromDiffAnalysis = previousResults.getResultFromClass(FineGrainDifftAnalyzer.class);
+
+		if (resultFromDiffAnalysis == null) {
+			System.err.println("Error Diff must be executed before");
+			throw new IllegalArgumentException("Error: missing diff");
+		}
+
+		// determine source and target file path
+		String path = revision.getFolder();
+		Map<String, File> filePaths = processFilesPair(new File(path));
+		File src = filePaths.get("src");
+		File target = filePaths.get("target");
+
+		Option option = new Option();
+		option.featureOption = FeatureOption.ORIGINAL;
+		CodeDiffer codeDiffer = new CodeDiffer(true, option);
+		//Get feature matrix
+		List<FeatureMatrix> featureMatrix = codeDiffer.runByGenerator(src, target);
+		//Get feature vector
+		JsonObject jsonfile = genVectorsCSV(option,target,featureMatrix);
+		
+		
+		JsonArray filesArray = new JsonArray();
+		filesArray.add(jsonfile);		
+		JsonObject root = new JsonObject();
+		root.addProperty("id", revision.getName());
+		root.add("features", filesArray);
+
+		return (new FeaturesResult(revision, root));
+
+	}
+
+	public Map processFilesPair(File pairFolder) {
+		Map<String, File> pathmap = new HashMap();
+
+		for (File fileModif : pairFolder.listFiles()) {
+
+			if (".DS_Store".equals(fileModif.getName()))
+				continue;
+
+			String pathname = fileModif.getAbsolutePath() + File.separator + pairFolder.getName() + "_"
+					+ fileModif.getName();
+
+			File previousVersion = new File(pathname + "_s.java");
+			if (!previousVersion.exists()) {
+				log.error("The source file " + previousVersion.getPath() + " not exist!");
+			} else {
+				pathmap.put("src", previousVersion);
+				File postVersion = new File(pathname + "_t.java");
+				pathmap.put("target", postVersion);
+
+			}
+
+		}
+		return pathmap;
+
+	}
+	
+	
+	 public JsonObject genVectorsCSV(Option option, File patchedFile, List<FeatureMatrix> featureMatrices) {
+	        ParameterVector parameterVector = new ParameterVector(option.featureOption);
+            List<String> valueList = null;
+	        List<String> header = new ArrayList<>();
+	        List<String> values = new ArrayList<>();
+           
+	        //Initial all vector  as 0.
+	        for (int idx = 0; idx < parameterVector.size(); idx++) {
+	            FeatureCross featureCross;
+	            featureCross = new OriginalFeatureCross(idx);
+                header.add(featureCross.getFeatures().toString());
+	            values.add("0");
+	        }
+	     
+	        //update value vector based on featureMatrices
+	        if (featureMatrices.size() == 1) {
+                for (FeatureVector featureVector : featureMatrices.get(0).getFeatureVectors()) {
+                	valueList = new ArrayList<>(values);
+                    List<FeatureCross> featureCrosses = featureVector.getFeatureCrosses();
+                    for (FeatureCross featureCross : featureCrosses) {
+                        valueList.set(featureCross.getId(), "1");
+                    }
+                }
+            }
+             
+	        JsonObject jsonfile = new JsonObject();
+	        for (int idx = 0; idx < parameterVector.size(); idx++) {
+	        	jsonfile.addProperty(header.get(idx), valueList.get(idx));
+	        }
+	       
+	       return jsonfile;
+	        
+	    }
+	
+	
+	
+
+}

--- a/src/main/java/fr/inria/coming/core/engine/files/FileDiff.java
+++ b/src/main/java/fr/inria/coming/core/engine/files/FileDiff.java
@@ -116,5 +116,9 @@ public class FileDiff implements IRevision {
 	public String toString() {
 		return "FileDiff [diffFolder=" + diffFolder + "]";
 	}
+	
+	public String getFolder() {
+		return diffFolder+"";
+	}
 
 }

--- a/src/main/java/fr/inria/coming/core/engine/filespair/FileDiff.java
+++ b/src/main/java/fr/inria/coming/core/engine/filespair/FileDiff.java
@@ -60,4 +60,10 @@ public class FileDiff implements IRevision {
         return "FileDiff [left=" + left.getName() + ", right=" + right.getName() + "]";
     }
 
+	@Override
+	public String getFolder() {
+		return "";
+	}
+    
+    
 }

--- a/src/main/java/fr/inria/coming/core/engine/git/CommitGit.java
+++ b/src/main/java/fr/inria/coming/core/engine/git/CommitGit.java
@@ -235,6 +235,12 @@ public class CommitGit implements Commit {
 		return getName();
 	}
 
+	@Override
+	public String getFolder() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }
 
 class MyTreeFilter extends TreeFilter {

--- a/src/main/java/fr/inria/coming/core/entities/output/FeaturesOutput.java
+++ b/src/main/java/fr/inria/coming/core/entities/output/FeaturesOutput.java
@@ -13,6 +13,8 @@ import com.google.gson.JsonParser;
 import fr.inria.coming.changeminer.entity.FinalResult;
 import fr.inria.coming.codefeatures.FeatureAnalyzer;
 import fr.inria.coming.codefeatures.FeaturesResult;
+import fr.inria.coming.codefeatures.P4JFeatureAnalyzer;
+import fr.inria.coming.core.entities.AnalysisResult;
 import fr.inria.coming.core.entities.RevisionResult;
 import fr.inria.coming.core.entities.interfaces.IOutput;
 import fr.inria.coming.main.ComingProperties;
@@ -39,12 +41,12 @@ public class FeaturesOutput implements IOutput {
 				continue;
 
 			FeaturesResult result = (FeaturesResult) rv.getResultFromClass(FeatureAnalyzer.class);
-			save(result);
+			save(result,"");
 		}
 
 	}
 
-	public JsonElement save(FeaturesResult result) {
+	public JsonElement save(FeaturesResult result, String featureType) {
 		JsonElement file = result.getFeatures();
 
 		FileWriter fw;
@@ -54,7 +56,7 @@ public class FeaturesOutput implements IOutput {
 			File fout = new File(ComingProperties.getProperty("output"));
 			fout.mkdirs();
 
-			String fileName = fout.getAbsolutePath() + File.separator + "features_" + result.getAnalyzed().getName()
+			String fileName = fout.getAbsolutePath() + File.separator +featureType +"features_" + result.getAnalyzed().getName()
 					+ ".json";
 			fw = new FileWriter(fileName);
 			Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -73,8 +75,16 @@ public class FeaturesOutput implements IOutput {
 
 	@Override
 	public void generateRevisionOutput(RevisionResult resultAllAnalyzed) {
-		FeaturesResult result = (FeaturesResult) resultAllAnalyzed.getResultFromClass(FeatureAnalyzer.class);
-		save(result);
+		FeaturesResult result = null;
+		//For Prophet4J features
+		if (resultAllAnalyzed.containsKey("P4JFeatureAnalyzer")) {
+			result = (FeaturesResult) resultAllAnalyzed.getResultFromClass(P4JFeatureAnalyzer.class);
+			save(result,"P4J");
+		}else {
+			result = (FeaturesResult) resultAllAnalyzed.getResultFromClass(FeatureAnalyzer.class);
+			save(result,"S4R");
+		}
+		
 	}
 
 }

--- a/src/test/java/fr/inria/coming/spoon/features/FeaturesOnComingMainTest.java
+++ b/src/test/java/fr/inria/coming/spoon/features/FeaturesOnComingMainTest.java
@@ -108,13 +108,14 @@ public class FeaturesOnComingMainTest {
 	 */
 	@Test
 	@Ignore
-	public void testFeaturesOnComingEvolutionFromFolder1() throws Exception {
+	public void testFeaturesOnS4REvolutionFromFolder1() throws Exception {
 		ComingMain main = new ComingMain();
 
 		CommandSummary cs = new CommandSummary();
 		cs.append("-input", "files");
 		cs.append("-location", (new File("src/main/resources/Defects4J_all_pairs")).getAbsolutePath());
 		cs.append("-mode", "features");
+		cs.append("-featuretype", "S4R");
 		cs.append("-output", "./out_features_d4j");
 		cs.append("-parameters", "outputperrevision:true");
 		FinalResult finalResult = null;
@@ -139,5 +140,48 @@ public class FeaturesOnComingMainTest {
 		}
 
 	}
+	
+	
+	/**
+	 * We ignore the execution of this test case: it takes hours, it does only
+	 * compute the features but it does not assert the behaviour
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	@Ignore
+	public void testFeaturesOnP4JEvolutionFromFolder1() throws Exception {
+		ComingMain main = new ComingMain();
+
+		CommandSummary cs = new CommandSummary();
+		cs.append("-input", "files");
+		cs.append("-location", (new File("src/main/resources/Defects4J_all_pairs")).getAbsolutePath());
+		cs.append("-mode", "features");
+		cs.append("-featuretype", "P4J");
+		cs.append("-output", "./out_features_d4j");
+		cs.append("-parameters", "outputperrevision:true");
+		FinalResult finalResult = null;
+
+		finalResult = main.run(cs.flat());
+
+		CommitFinalResult commitResult = (CommitFinalResult) finalResult;
+
+		assertTrue(commitResult.getAllResults().values().size() > 0);
+
+		for (Commit iCommit : commitResult.getAllResults().keySet()) {
+
+			RevisionResult resultofCommit = commitResult.getAllResults().get(iCommit);
+			// Get the results of this analyzer
+			AnalysisResult featureResult = resultofCommit.get(FeatureAnalyzer.class.getSimpleName());
+
+			assertTrue(featureResult instanceof FeaturesResult);
+			FeaturesResult fresults = (FeaturesResult) featureResult;
+			assertNotNull(fresults);
+			assertNotNull(fresults.getFeatures());
+
+		}
+
+	}
+	
 
 }


### PR DESCRIPTION
Hi Matias,

I think it may be useful to enable Prophet4J to generate features for files under the following structure as Sketch4Repair does.

<location_arg>
├── <diff_folder>
│   └── <modif_file>
│       ├── <diff_folder>_<modif_file>_s.java
│       └── <diff_folder>_<modif_file>_t.java


In this pull request, you can find the following changes:
(1) a new parameter - featuretype to specify feature tools(ComingMain.java).
(2) a new P4J analyzer for generating P4J feature (P4JFeatureAnalyzer.java) .
(3) slightly changes  in the way to save output JSON file: with a prefix (FeaturesOutput.java) .
(4) a corresponding test (FeaturesOnComingMainTest.java).
(5) an update at READMe.

