### PR TITLE
Each analyzer has now a key. By default, it's the class name.

### DIFF
--- a/src/main/java/fr/inria/coming/core/engine/Analyzer.java
+++ b/src/main/java/fr/inria/coming/core/engine/Analyzer.java
@@ -21,4 +21,13 @@ public interface Analyzer<T extends IRevision> {
 	 */
 	public AnalysisResult analyze(T input, RevisionResult previousResults);
 
+	/**
+	 * Returns the Key (identfier) of the Analyzer. By default is the class name.
+	 * 
+	 * @return
+	 */
+	public default String key() {
+		return this.getClass().getSimpleName();
+	}
+
 }

--- a/src/main/java/fr/inria/coming/core/engine/RevisionNavigationExperiment.java
+++ b/src/main/java/fr/inria/coming/core/engine/RevisionNavigationExperiment.java
@@ -119,7 +119,7 @@ public abstract class RevisionNavigationExperiment<R extends IRevision> {
 				for (Analyzer analyzer : analyzers) {
 
 					AnalysisResult resultAnalyzer = analyzer.analyze(oneRevision, resultAllAnalyzed);
-					resultAllAnalyzed.put(analyzer.getClass().getSimpleName(), resultAnalyzer);
+					resultAllAnalyzed.put(analyzer.key(), resultAnalyzer);
 					if (resultAnalyzer == null || !resultAnalyzer.sucessful()) {
 						log.debug(String.format("The result of the analyzer %s  was not sucessful",
 								analyzer.getClass().getSimpleName()));


### PR DESCRIPTION
This allows to register the same analyzer (parametrized) more than one time.