### PR TITLE
"include_all_instances", "exclude_not_covering_patterns" and "print_only_repair_results" options added.

### DIFF
--- a/coming_results/all_instances_found.json
+++ b/coming_results/all_instances_found.json
@@ -1,0 +1,39 @@
+{
+  "instances": [
+    {
+      "revision": "covered",
+      "repairability": [
+        {
+          "tool-name": "Elixir",
+          "pattern-name": "Elixir;update_typre_ref",
+          "Unified_Diff_of-files:": "Starts Below...",
+          "INSERT:": "import javarepl.expressions.Type;",
+          "instance_detail": [
+            {
+              "pattern_action": "UPD",
+              "pattern_entity": {
+                "entity_type": "TypeReference",
+                "entity_new value": "*",
+                "entity_role": "*",
+                "entity_parent": "null"
+              },
+              "concrete_change": {
+                "operator": "UPD",
+                "src_type": "TypeReference",
+                "dst_type": "TypeReference",
+                "src": "javarepl.Type",
+                "dst": "javarepl.expressions.Type",
+                "src_parent_type": "Parameter",
+                "dst_parent_type": "Parameter",
+                "src_parent": "javarepl.Type expression",
+                "dst_parent": "javarepl.expressions.Type expression"
+              },
+              "line": 204,
+              "file": "D:\\Daneshgah\\phd-kth\\projects\\commit summarization\\template-based\\coming\\covered"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/fr/inria/coming/changeminer/analyzer/instancedetector/DetectorChangePatternInstanceEngine.java
+++ b/src/main/java/fr/inria/coming/changeminer/analyzer/instancedetector/DetectorChangePatternInstanceEngine.java
@@ -31,495 +31,495 @@ import gumtree.spoon.diff.operations.UpdateOperation;
 import spoon.reflect.declaration.CtElement;
 
 /**
- * 
+ *
  * @author Matias Martinez
  *
  */
 public class DetectorChangePatternInstanceEngine {
 
-	Logger log = Logger.getLogger(this.getClass().getName());
+    Logger log = Logger.getLogger(this.getClass().getName());
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public List<ChangePatternInstance> findPatternInstances(ChangePatternSpecification changePatternSpecification,
-			Diff diffToAnalyze) {
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public List<ChangePatternInstance> findPatternInstances(ChangePatternSpecification changePatternSpecification,
+                                                            Diff diffToAnalyze) {
 
-		ResultMapping mapping = mappingActions(changePatternSpecification, diffToAnalyze);
+        ResultMapping mapping = mappingActions(changePatternSpecification, diffToAnalyze);
 
-		log.debug("Diff size " + diffToAnalyze.getAllOperations().size() + ": "
-				+ diffToAnalyze.getAllOperations().stream()
-						.map(e -> e.getClass().getSimpleName() + " " + e.getSrcNode().getClass().getSimpleName())
-						.collect(Collectors.joining(" - ")));
+        log.debug("Diff size " + diffToAnalyze.getAllOperations().size() + ": "
+                + diffToAnalyze.getAllOperations().stream()
+                .map(e -> e.getClass().getSimpleName() + " " + e.getSrcNode().getClass().getSimpleName())
+                .collect(Collectors.joining(" - ")));
 
-		log.debug("#Mapped  " + mapping.mappings.size() + " #NotMapped " + mapping.notMapped.size());
+        log.debug("#Mapped  " + mapping.mappings.size() + " #NotMapped " + mapping.notMapped.size());
 
-		if (!mapping.getNotMapped().isEmpty()) {
-			log.debug("There are pattern actions not mapped: " + mapping.getNotMapped());
-			return Collections.EMPTY_LIST;
-		}
-		List<ChangePatternInstance> instances = calculateValidInstancesFromMapping(changePatternSpecification,
-				mapping.getMappings());
+        if (!mapping.getNotMapped().isEmpty()) {
+            log.debug("There are pattern actions not mapped: " + mapping.getNotMapped());
+            return Collections.EMPTY_LIST;
+        }
+        List<ChangePatternInstance> instances = calculateValidInstancesFromMapping(changePatternSpecification,
+                mapping.getMappings());
 
-		return instances;
+        return instances;
 
-	}
+    }
 
-	public List<ChangePatternInstance> calculateValidInstancesFromMapping(
-			ChangePatternSpecification changePatternSpecification, MapList<PatternAction, MatchingAction> matching) {
+    public List<ChangePatternInstance> calculateValidInstancesFromMapping(
+            ChangePatternSpecification changePatternSpecification, MapList<PatternAction, MatchingAction> matching) {
 
-		List<ChangePatternInstance> instancesFinalSet = new ArrayList<>();
-
-		// All Combinations
-		List<ChangePatternInstance> instancesAllCombinations = (ComingProperties.getPropertyBoolean("singleinstance"))
-				? singleInstance(changePatternSpecification, matching)
-				: allCombinations(changePatternSpecification, matching);
-
-		instancesAllCombinations = instancesAllCombinations.stream().filter(e -> validate(e))
-				.collect(Collectors.toList());
-
-		// Discarding illegal relations
-		// First, get relations between elements of the pattern
-		PatternRelations relations = changePatternSpecification.calculateRelations();
-
-		// For each instance
-		for (ChangePatternInstance instance : instancesAllCombinations) {
-
-			if (!checkUnchangedActionAlsoUsedByOther(instance)) {
-				if (checkInvalidInstanceExistance(instance, relations)) {
-					instancesFinalSet.clear();
-					return instancesFinalSet;
-				}
-
-				continue;
-			}
-
-			log.debug("Analyzing  instance: \n" + instance);
-			if (checkPatternRelationsOnInstance(instance, relations)) {
-				instancesFinalSet.add(instance);
-			}
-
-		}
-
-		return instancesFinalSet;
-
-	}
-
-	/**
-	 * We return a single instance, with the mapping to the first element. It can we
-	 * use when it's necessary to assert the presence of a pattern instance, but we
-	 * dont want to analyze them.
-	 * 
-	 * @param changePatternSpecification
-	 * @param matching
-	 * @return
-	 */
-	private List<ChangePatternInstance> singleInstance(ChangePatternSpecification changePatternSpecification,
-			MapList<PatternAction, MatchingAction> matching) {
-		List<ChangePatternInstance> instancesAllCombinations = new ArrayList<>();
-
-		ChangePatternInstance ins = new ChangePatternInstance(changePatternSpecification);
-		for (PatternAction pa : matching.keySet()) {
-
-			List<ChangePatternInstance> temp = new ArrayList<>();
-
-			List<MatchingAction> actions = matching.get(pa);
-
-			MatchingAction matchingAction = actions.get(0);
-
-			ins.addInstance(matchingAction.getPatternAction(), matchingAction.getOperation());
-			ins.getMapping().put(pa, matchingAction);
-
-			temp.add(ins);
-
-			instancesAllCombinations.clear();
-			instancesAllCombinations.addAll(temp);
-		}
-		return instancesAllCombinations;
-	}
-
-	public List<ChangePatternInstance> allCombinations(ChangePatternSpecification changePatternSpecification,
-			MapList<PatternAction, MatchingAction> matching) {
-
-		List<ChangePatternInstance> instancesAllCombinations = new ArrayList<>();
-
-		for (PatternAction pa : matching.keySet()) {
-
-			List<ChangePatternInstance> temp = new ArrayList<>();
-
-			List<MatchingAction> actions = matching.get(pa);
-			for (MatchingAction matchingAction : actions) {
-				if (instancesAllCombinations.isEmpty()) {
-					ChangePatternInstance ins = new ChangePatternInstance(changePatternSpecification);
-					ins.addInstance(matchingAction.getPatternAction(), matchingAction.getOperation());
-					ins.getMapping().put(pa, matchingAction);
-					temp.add(ins);
-				} else {
-					for (ChangePatternInstance changePatternInstance : instancesAllCombinations) {
-						ChangePatternInstance ins = new ChangePatternInstance(changePatternSpecification);
-						ins.getActionOperation().putAll(changePatternInstance.getActionOperation());
-						ins.getActions().addAll(changePatternInstance.getActions());
-						ins.getMapping().putAll(changePatternInstance.getMapping());
-						ins.addInstance(matchingAction.getPatternAction(), matchingAction.getOperation());
-						ins.getMapping().put(pa, matchingAction);
-						temp.add(ins);
-					}
-				}
-			}
-			instancesAllCombinations.clear();
-			instancesAllCombinations.addAll(temp);
-		}
-		return instancesAllCombinations;
-	}
-
-	/**
-	 * 
-	 * 
-	 * @param instance
-	 * @return
-	 */
-	public boolean validate(ChangePatternInstance instance) {
-		return checkAbsenceNotMappedAction(instance) && checkEntitiesUsedOne(instance);
-	}
-
-	/**
-	 * This method checks if the entities are used correctly: eg,
-	 * 
-	 * @param instance
-	 * @return
-	 */
-	public boolean checkAbsenceNotMappedAction(ChangePatternInstance instance) {
-		for (PatternAction paction : instance.actionOperation.keySet()) {
-
-			if (!instance.getMapping().containsKey(paction)) {
-				log.debug("The action has not mapping: " + paction);
-				return false;
-			}
-
-			MatchingAction matchingAction = instance.getMapping().get(paction);
-
-			if (matchingAction.getMatching().isEmpty()) {
-				log.debug("The mappings for action is empty: " + paction);
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * This method ckecks if the entities are used correctly: eg,
-	 * 
-	 * @param instance
-	 * @return
-	 */
-	private boolean checkEntitiesUsedOne(ChangePatternInstance instance) {
-		List<Integer> ids = new ArrayList<>();
-		Map<CtElement, Integer> entitiesById = new java.util.HashMap<>();
-		for (PatternAction paction : instance.actionOperation.keySet()) {
-			if (paction.getAction().isUnchanged()) {
-				continue;
-			}
-
-			MatchingAction matchingAction = instance.getMapping().get(paction);
-
-			// The first one is always pointed by an action.
-			MatchingEntity firstMatchingEntity = matchingAction.getMatching().get(0);
-			int id = firstMatchingEntity.patternEntity.getId();
-			if (id > 0 && ids.contains(id)) {
-				log.debug("Another action affect the same Entity: " + id);
-				return false;
-			} else {
-				ids.add(id);
-
-				CtElement affected = firstMatchingEntity.getAffectedNode();
-
-				if (entitiesById.containsKey(affected) && entitiesById.get(affected) != id) {
-					// The same entity mapped to another entity
-					log.debug("Same entity used twise: " + id);
-					return false;
-				}
-				entitiesById.put(affected, id);
-			}
-		}
-		return true;
-	}
-
-	/***
-	 * For a ChangedPatternInstance, if it is matched by an entity with UNCHANGED
-	 * action, which is with lower prior, it's valid only if the entity is also
-	 * matched by the other entities. Because entity ids cannot be the same, and we
-	 * want the UNCHANGED entities to match nothing.
-	 *
-	 * @param instance
-	 * @return
-	 */
-	private boolean checkUnchangedActionAlsoUsedByOther(ChangePatternInstance instance) {
-		Set<CtElement> mustMatchedEntities = new HashSet<>();
-		for (PatternAction paction : instance.actionOperation.keySet()) {
-			if (!paction.getAction().isUnchanged()) {
-				continue;
-			}
-
-			MatchingAction matchingAction = instance.getMapping().get(paction);
-			// The first one is always pointed by an action.
-			MatchingEntity firstMatchingEntity = matchingAction.getMatching().get(0);
-			CtElement affected = firstMatchingEntity.getAffectedNode();
-			mustMatchedEntities.add(affected);
-		}
-
-		for (PatternAction paction : instance.actionOperation.keySet()) {
-			if (paction.getAction().isUnchanged()) {
-				continue;
-			}
-
-			MatchingAction matchingAction = instance.getMapping().get(paction);
-			// The first one is always pointed by an action.
-			MatchingEntity firstMatchingEntity = matchingAction.getMatching().get(0);
-			CtElement affected = firstMatchingEntity.getAffectedNode();
-			if (mustMatchedEntities.contains(affected)) {
-				mustMatchedEntities.remove(affected);
-			}
-		}
-
-		return mustMatchedEntities.isEmpty();
-	}
-
-	/**
-	 * Returns true if the instance of a pattern respect the relation between the
-	 * elements of the pattern.
-	 * 
-	 * @param instance
-	 * @param relations
-	 * @return
-	 */
-	/**
-	 * Returns true if the instance of a pattern respect the relation between the
-	 * elements of the pattern.
-	 *
-	 * @param instance
-	 * @param relations
-	 * @return
-	 */
-	public boolean checkPatternRelationsOnInstance(ChangePatternInstance instance, PatternRelations relations) {
-		return checkPatternRelationsOnInstance(instance, relations, true);
-	}
-
-	public boolean checkInvalidInstanceExistance(ChangePatternInstance invalid, PatternRelations relations) {
-		return checkPatternRelationsOnInstance(invalid, relations, false);
-	}
-
-	private boolean checkPatternRelationsOnInstance(ChangePatternInstance instance, PatternRelations relations,
-			boolean checkUnchanged) {
-
-		MapList<PatternAction, EntityRelation> entitiesByAction = relations.getPaEntity();
-
-		// for each patter action, let's check if the elements that it points respect
-		// the relation defined by the pattern
-		for (PatternAction paction : instance.actionOperation.keySet()) {
-			// if the pattern action has a relation
-			if (entitiesByAction.containsKey(paction)) {
-				// It has relation:
-				List<EntityRelation> relationsOfPatternAction = entitiesByAction.get(paction);
-				for (EntityRelation entityRelation : relationsOfPatternAction) {
-					// Get the two actions related by the Relation (one of them is paction)
-					PatternAction actionA = entityRelation.getAction1();
-					PatternAction actionB = entityRelation.getAction2();
-					boolean aInMapping = instance.getMapping().containsKey(actionA);
-					boolean bInMapping = instance.getMapping().containsKey(actionB);
-					if (checkUnchanged) {
-						boolean isAUnchanged = actionA.getAction().isUnchanged();
-						boolean isBUnchanged = actionB.getAction().isUnchanged();
-						if ((!aInMapping && !isAUnchanged) || (!bInMapping && !isBUnchanged)) {
-							return false;
-						}
-
-						if (!aInMapping || !bInMapping) {
-							continue;
-						}
-					} else {
-						if (!aInMapping || !bInMapping) {
-							return false;
-						}
-					}
-
-					// get the matching of each action
-					MatchingEntity meA = instance.getMapping().get(actionA).getMatching().stream()
-							.filter(e -> e.patternEntity == entityRelation.getEntity()).findFirst().get();
-
-					MatchingEntity meB = instance.getMapping().get(actionB).getMatching().stream()
-							.filter(e -> e.patternEntity == entityRelation.getEntity()).findFirst().get();
-
-					// == comparing objects.
-					// if the Object referenced by an action is the same than that one referenced by
-					// the related action B, then continue, otherwise discard instance, the relation
-					// is not respected in that instance
-					CtElement affectedNodeA = meA.getAffectedNode();
-					CtElement affectedNodeB = meB.getAffectedNode();
-					if (affectedNodeA != affectedNodeB) {
-						// Discard instance
-						return false;
-					}
-
-				}
-
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * Receives a pattern specification and a diff and creates a mapping between
-	 * elements from the pattern and those affected by the diff
-	 * 
-	 * @param changePatternSpecification
-	 * @param diffToAnalyze
-	 * @return
-	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public ResultMapping mappingActions(ChangePatternSpecification changePatternSpecification, Diff diffToAnalyze) {
-		List<Operation> operationsFromDiff = diffToAnalyze.getAllOperations();
-
-		MapList<PatternAction, MatchingAction> mapping = new MapList<>();
-		List<PatternAction> notMapped = new ArrayList();
-
-		// For each abstract change in the pattern
-		for (PatternAction patternAction : changePatternSpecification.getAbstractChanges()) {
-			boolean mapped = false;
-			ActionType patternOperationType = getOperationType(patternAction);
-			// For each operation in the diff
-			for (Operation operation : operationsFromDiff) {
-
-				Action action = operation.getAction();
-				// First, match the type of the action
-				if (matchActionTypes(action, patternOperationType)) {
-					// when, match the elements affected by the action.
-					List<MatchingEntity> matching = matchElements(operation, patternAction.getAffectedEntity());
-
-					if (matching != null && !matching.isEmpty()) {
-						mapped = true;
-						MatchingAction maction = new MatchingAction(operation, patternAction, matching);
-						if (patternOperationType.equals(ActionType.UNCHANGED_HIGH_PRIORITY)) {
-							notMapped.add(patternAction);
-						} else {
-							mapping.add(patternAction, maction);
-						}
-					}
-				}
-			}
-			if (!mapped) {
-				if (patternOperationType.isUnchanged()) {
-					continue;
-				}
-
-				log.debug("Abstract change not mapped: " + patternAction);
-				notMapped.add(patternAction);
-			}
-		}
-		return new ResultMapping(mapping, notMapped);
-	}
-
-	/**
-	 * Match the element affected by an operation from the diff and the elements in
-	 * the pattern specification
-	 * 
-	 * @param affectedOperation
-	 * @param affectedEntity
-	 * @return
-	 */
-	private List<MatchingEntity> matchElements(Operation affectedOperation, PatternEntity affectedEntity) {
-
-		List<MatchingEntity> matching = new ArrayList<>();
-
-		int parentLevel = 1;
-		PatternEntity parentEntity = affectedEntity;
-		// Let's get the parent of the affected
-		CtElement currentNodeFromAction = null;
-		boolean matchnewvalue = false;
-
-		// Search the node to select according to the type of operation and the pattern
-		if (affectedOperation.getDstNode() != null && affectedEntity.getNewValue() != null) {
-			currentNodeFromAction = affectedOperation.getDstNode();
-			matchnewvalue = true;
-		} else if (affectedOperation instanceof UpdateOperation && (affectedEntity.getOldValue() != null)) {
-			currentNodeFromAction = affectedOperation.getSrcNode();
-			matchnewvalue = false;
-		} else {
-			matchnewvalue = true;
-			currentNodeFromAction = affectedOperation.getNode();
-		}
-
-		int i_levels = 1;
-		// Scale the parent hierarchy and check types.
-		while (currentNodeFromAction != null && i_levels <= parentLevel) {
-			String typeOfNode = getNodeLabelFromCtElement(currentNodeFromAction);
-			String valueOfNode = currentNodeFromAction.toString();
-			String roleInParent = (currentNodeFromAction.getRoleInParent() != null)
-					? currentNodeFromAction.getRoleInParent().toString().toLowerCase()
-					: "";
-
-			String patternEntityValue = (matchnewvalue) ? parentEntity.getNewValue() : parentEntity.getOldValue();
-			if ( // type of element
-			("*".equals(parentEntity.getEntityType())
-					|| (typeOfNode != null && typeOfNode.equals(parentEntity.getEntityType())))
-					///
-					&&
-					// value of element
-					("*".equals(patternEntityValue) || (valueOfNode != null && valueOfNode.equals(patternEntityValue)))
-					//
-					&&
-					// role
-					("*".equals(parentEntity.getRoleInParent()) || (roleInParent != null
-							&& roleInParent.equals(parentEntity.getRoleInParent().toLowerCase())))) {
-				MatchingEntity match = new MatchingEntity(currentNodeFromAction, parentEntity);
-				matching.add(match);
-
-				ParentPatternEntity parentEntityFromPattern = parentEntity.getParentPatternEntity();
-				if (parentEntityFromPattern == null) {
-					return matching;
-				}
-				i_levels = 1;
-				parentLevel = parentEntityFromPattern.getParentLevel();
-				parentEntity = parentEntityFromPattern.getParent();
-
-			} else {
-				// Not match
-				i_levels++;
-			}
-			currentNodeFromAction = currentNodeFromAction.getParent();
-		}
-		// Not all matched
-		return null;
-
-	}
-
-	private boolean matchActionTypes(Action action, ActionType type) {
-
-		return ActionType.ANY.equals(type) || ActionType.UNCHANGED.equals(type)
-				|| ActionType.UNCHANGED_HIGH_PRIORITY.equals(type)
-				|| (type.equals(ActionType.INS) && (action instanceof Insert))
-				|| (type.equals(ActionType.DEL) && (action instanceof Delete))
-				|| (type.equals(ActionType.MOV) && (action instanceof Move))
-				|| (type.equals(ActionType.UPD) && (action instanceof Update));
-	}
-
-	public ActionType getOperationType(PatternAction patternAction) {
-		return patternAction.getAction();
-	}
-
-	public String getTypeLabel(PatternAction patternAction) {
-		return patternAction.getAffectedEntity().getEntityType();
-	}
-
-	/**
-	 * The label of a CtElement is the simple name of the class without the CT
-	 * prefix.
-	 * 
-	 * @param element
-	 * @return
-	 */
-	public String getNodeLabelFromCtElement(CtElement element) {
-		String typeFromCt = element.getClass().getSimpleName();
-		if (typeFromCt.trim().isEmpty())
-			return typeFromCt;
-		return typeFromCt.substring(2, typeFromCt.length() - 4);
-	}
+        List<ChangePatternInstance> instancesFinalSet = new ArrayList<>();
+
+        // All Combinations
+        List<ChangePatternInstance> instancesAllCombinations = (ComingProperties.getPropertyBoolean("singleinstance"))
+                ? singleInstance(changePatternSpecification, matching)
+                : allCombinations(changePatternSpecification, matching);
+
+        instancesAllCombinations = instancesAllCombinations.stream().filter(e -> validate(e))
+                .collect(Collectors.toList());
+
+        // Discarding illegal relations
+        // First, get relations between elements of the pattern
+        PatternRelations relations = changePatternSpecification.calculateRelations();
+
+        // For each instance
+        for (ChangePatternInstance instance : instancesAllCombinations) {
+
+            if (!checkUnchangedActionAlsoUsedByOther(instance)) {
+                if (checkInvalidInstanceExistance(instance, relations)) {
+                    instancesFinalSet.clear();
+                    return instancesFinalSet;
+                }
+
+                continue;
+            }
+
+            log.debug("Analyzing  instance: \n" + instance);
+            if (checkPatternRelationsOnInstance(instance, relations)) {
+                instancesFinalSet.add(instance);
+            }
+
+        }
+
+        return instancesFinalSet;
+
+    }
+
+    /**
+     * We return a single instance, with the mapping to the first element. It can we
+     * use when it's necessary to assert the presence of a pattern instance, but we
+     * dont want to analyze them.
+     *
+     * @param changePatternSpecification
+     * @param matching
+     * @return
+     */
+    private List<ChangePatternInstance> singleInstance(ChangePatternSpecification changePatternSpecification,
+                                                       MapList<PatternAction, MatchingAction> matching) {
+        List<ChangePatternInstance> instancesAllCombinations = new ArrayList<>();
+
+        ChangePatternInstance ins = new ChangePatternInstance(changePatternSpecification);
+        for (PatternAction pa : matching.keySet()) {
+
+            List<ChangePatternInstance> temp = new ArrayList<>();
+
+            List<MatchingAction> actions = matching.get(pa);
+
+            MatchingAction matchingAction = actions.get(0);
+
+            ins.addInstance(matchingAction.getPatternAction(), matchingAction.getOperation());
+            ins.getMapping().put(pa, matchingAction);
+
+            temp.add(ins);
+
+            instancesAllCombinations.clear();
+            instancesAllCombinations.addAll(temp);
+        }
+        return instancesAllCombinations;
+    }
+
+    public List<ChangePatternInstance> allCombinations(ChangePatternSpecification changePatternSpecification,
+                                                       MapList<PatternAction, MatchingAction> matching) {
+
+        List<ChangePatternInstance> instancesAllCombinations = new ArrayList<>();
+
+        for (PatternAction pa : matching.keySet()) {
+
+            List<ChangePatternInstance> temp = new ArrayList<>();
+
+            List<MatchingAction> actions = matching.get(pa);
+            for (MatchingAction matchingAction : actions) {
+                if (instancesAllCombinations.isEmpty()) {
+                    ChangePatternInstance ins = new ChangePatternInstance(changePatternSpecification);
+                    ins.addInstance(matchingAction.getPatternAction(), matchingAction.getOperation());
+                    ins.getMapping().put(pa, matchingAction);
+                    temp.add(ins);
+                } else {
+                    for (ChangePatternInstance changePatternInstance : instancesAllCombinations) {
+                        ChangePatternInstance ins = new ChangePatternInstance(changePatternSpecification);
+                        ins.getActionOperation().putAll(changePatternInstance.getActionOperation());
+                        ins.getActions().addAll(changePatternInstance.getActions());
+                        ins.getMapping().putAll(changePatternInstance.getMapping());
+                        ins.addInstance(matchingAction.getPatternAction(), matchingAction.getOperation());
+                        ins.getMapping().put(pa, matchingAction);
+                        temp.add(ins);
+                    }
+                }
+            }
+            instancesAllCombinations.clear();
+            instancesAllCombinations.addAll(temp);
+        }
+        return instancesAllCombinations;
+    }
+
+    /**
+     *
+     *
+     * @param instance
+     * @return
+     */
+    public boolean validate(ChangePatternInstance instance) {
+        return checkAbsenceNotMappedAction(instance) && checkEntitiesUsedOne(instance);
+    }
+
+    /**
+     * This method checks if the entities are used correctly: eg,
+     *
+     * @param instance
+     * @return
+     */
+    public boolean checkAbsenceNotMappedAction(ChangePatternInstance instance) {
+        for (PatternAction paction : instance.actionOperation.keySet()) {
+
+            if (!instance.getMapping().containsKey(paction)) {
+                log.debug("The action has not mapping: " + paction);
+                return false;
+            }
+
+            MatchingAction matchingAction = instance.getMapping().get(paction);
+
+            if (matchingAction.getMatching().isEmpty()) {
+                log.debug("The mappings for action is empty: " + paction);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * This method ckecks if the entities are used correctly: eg,
+     *
+     * @param instance
+     * @return
+     */
+    private boolean checkEntitiesUsedOne(ChangePatternInstance instance) {
+        List<Integer> ids = new ArrayList<>();
+        Map<CtElement, Integer> entitiesById = new java.util.HashMap<>();
+        for (PatternAction paction : instance.actionOperation.keySet()) {
+            if (paction.getAction().isUnchanged()) {
+                continue;
+            }
+
+            MatchingAction matchingAction = instance.getMapping().get(paction);
+
+            // The first one is always pointed by an action.
+            MatchingEntity firstMatchingEntity = matchingAction.getMatching().get(0);
+            int id = firstMatchingEntity.patternEntity.getId();
+            if (id > 0 && ids.contains(id)) {
+                log.debug("Another action affect the same Entity: " + id);
+                return false;
+            } else {
+                ids.add(id);
+
+                CtElement affected = firstMatchingEntity.getAffectedNode();
+
+                if (entitiesById.containsKey(affected) && entitiesById.get(affected) != id) {
+                    // The same entity mapped to another entity
+                    log.debug("Same entity used twise: " + id);
+                    return false;
+                }
+                entitiesById.put(affected, id);
+            }
+        }
+        return true;
+    }
+
+    /***
+     * For a ChangedPatternInstance, if it is matched by an entity with UNCHANGED
+     * action, which is with lower prior, it's valid only if the entity is also
+     * matched by the other entities. Because entity ids cannot be the same, and we
+     * want the UNCHANGED entities to match nothing.
+     *
+     * @param instance
+     * @return
+     */
+    private boolean checkUnchangedActionAlsoUsedByOther(ChangePatternInstance instance) {
+        Set<CtElement> mustMatchedEntities = new HashSet<>();
+        for (PatternAction paction : instance.actionOperation.keySet()) {
+            if (!paction.getAction().isUnchanged()) {
+                continue;
+            }
+
+            MatchingAction matchingAction = instance.getMapping().get(paction);
+            // The first one is always pointed by an action.
+            MatchingEntity firstMatchingEntity = matchingAction.getMatching().get(0);
+            CtElement affected = firstMatchingEntity.getAffectedNode();
+            mustMatchedEntities.add(affected);
+        }
+
+        for (PatternAction paction : instance.actionOperation.keySet()) {
+            if (paction.getAction().isUnchanged()) {
+                continue;
+            }
+
+            MatchingAction matchingAction = instance.getMapping().get(paction);
+            // The first one is always pointed by an action.
+            MatchingEntity firstMatchingEntity = matchingAction.getMatching().get(0);
+            CtElement affected = firstMatchingEntity.getAffectedNode();
+            if (mustMatchedEntities.contains(affected)) {
+                mustMatchedEntities.remove(affected);
+            }
+        }
+
+        return mustMatchedEntities.isEmpty();
+    }
+
+    /**
+     * Returns true if the instance of a pattern respect the relation between the
+     * elements of the pattern.
+     *
+     * @param instance
+     * @param relations
+     * @return
+     */
+    /**
+     * Returns true if the instance of a pattern respect the relation between the
+     * elements of the pattern.
+     *
+     * @param instance
+     * @param relations
+     * @return
+     */
+    public boolean checkPatternRelationsOnInstance(ChangePatternInstance instance, PatternRelations relations) {
+        return checkPatternRelationsOnInstance(instance, relations, true);
+    }
+
+    public boolean checkInvalidInstanceExistance(ChangePatternInstance invalid, PatternRelations relations) {
+        return checkPatternRelationsOnInstance(invalid, relations, false);
+    }
+
+    private boolean checkPatternRelationsOnInstance(ChangePatternInstance instance, PatternRelations relations,
+                                                    boolean checkUnchanged) {
+
+        MapList<PatternAction, EntityRelation> entitiesByAction = relations.getPaEntity();
+
+        // for each patter action, let's check if the elements that it points respect
+        // the relation defined by the pattern
+        for (PatternAction paction : instance.actionOperation.keySet()) {
+            // if the pattern action has a relation
+            if (entitiesByAction.containsKey(paction)) {
+                // It has relation:
+                List<EntityRelation> relationsOfPatternAction = entitiesByAction.get(paction);
+                for (EntityRelation entityRelation : relationsOfPatternAction) {
+                    // Get the two actions related by the Relation (one of them is paction)
+                    PatternAction actionA = entityRelation.getAction1();
+                    PatternAction actionB = entityRelation.getAction2();
+                    boolean aInMapping = instance.getMapping().containsKey(actionA);
+                    boolean bInMapping = instance.getMapping().containsKey(actionB);
+                    if (checkUnchanged) {
+                        boolean isAUnchanged = actionA.getAction().isUnchanged();
+                        boolean isBUnchanged = actionB.getAction().isUnchanged();
+                        if ((!aInMapping && !isAUnchanged) || (!bInMapping && !isBUnchanged)) {
+                            return false;
+                        }
+
+                        if (!aInMapping || !bInMapping) {
+                            continue;
+                        }
+                    } else {
+                        if (!aInMapping || !bInMapping) {
+                            return false;
+                        }
+                    }
+
+                    // get the matching of each action
+                    MatchingEntity meA = instance.getMapping().get(actionA).getMatching().stream()
+                            .filter(e -> e.patternEntity == entityRelation.getEntity()).findFirst().get();
+
+                    MatchingEntity meB = instance.getMapping().get(actionB).getMatching().stream()
+                            .filter(e -> e.patternEntity == entityRelation.getEntity()).findFirst().get();
+
+                    // == comparing objects.
+                    // if the Object referenced by an action is the same than that one referenced by
+                    // the related action B, then continue, otherwise discard instance, the relation
+                    // is not respected in that instance
+                    CtElement affectedNodeA = meA.getAffectedNode();
+                    CtElement affectedNodeB = meB.getAffectedNode();
+                    if (affectedNodeA != affectedNodeB) {
+                        // Discard instance
+                        return false;
+                    }
+
+                }
+
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Receives a pattern specification and a diff and creates a mapping between
+     * elements from the pattern and those affected by the diff
+     *
+     * @param changePatternSpecification
+     * @param diffToAnalyze
+     * @return
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public ResultMapping mappingActions(ChangePatternSpecification changePatternSpecification, Diff diffToAnalyze) {
+        List<Operation> operationsFromDiff = diffToAnalyze.getAllOperations();
+
+        MapList<PatternAction, MatchingAction> mapping = new MapList<>();
+        List<PatternAction> notMapped = new ArrayList();
+
+        // For each abstract change in the pattern
+        for (PatternAction patternAction : changePatternSpecification.getAbstractChanges()) {
+            boolean mapped = false;
+            ActionType patternOperationType = getOperationType(patternAction);
+            // For each operation in the diff
+            for (Operation operation : operationsFromDiff) {
+
+                Action action = operation.getAction();
+                // First, match the type of the action
+                if (matchActionTypes(action, patternOperationType)) {
+                    // when, match the elements affected by the action.
+                    List<MatchingEntity> matching = matchElements(operation, patternAction.getAffectedEntity());
+
+                    if (matching != null && !matching.isEmpty()) {
+                        mapped = true;
+                        MatchingAction maction = new MatchingAction(operation, patternAction, matching);
+                        if (patternOperationType.equals(ActionType.UNCHANGED_HIGH_PRIORITY)) {
+                            notMapped.add(patternAction);
+                        } else {
+                            mapping.add(patternAction, maction);
+                        }
+                    }
+                }
+            }
+            if (!mapped) {
+                if (patternOperationType.isUnchanged()) {
+                    continue;
+                }
+
+                log.debug("Abstract change not mapped: " + patternAction);
+                notMapped.add(patternAction);
+            }
+        }
+        return new ResultMapping(mapping, notMapped);
+    }
+
+    /**
+     * Match the element affected by an operation from the diff and the elements in
+     * the pattern specification
+     *
+     * @param affectedOperation
+     * @param affectedEntity
+     * @return
+     */
+    private List<MatchingEntity> matchElements(Operation affectedOperation, PatternEntity affectedEntity) {
+
+        List<MatchingEntity> matching = new ArrayList<>();
+
+        int parentLevel = 1;
+        PatternEntity parentEntity = affectedEntity;
+        // Let's get the parent of the affected
+        CtElement currentNodeFromAction = null;
+        boolean matchnewvalue = false;
+
+        // Search the node to select according to the type of operation and the pattern
+        if (affectedOperation.getDstNode() != null && affectedEntity.getNewValue() != null) {
+            currentNodeFromAction = affectedOperation.getDstNode();
+            matchnewvalue = true;
+        } else if (affectedOperation instanceof UpdateOperation && (affectedEntity.getOldValue() != null)) {
+            currentNodeFromAction = affectedOperation.getSrcNode();
+            matchnewvalue = false;
+        } else {
+            matchnewvalue = true;
+            currentNodeFromAction = affectedOperation.getNode();
+        }
+
+        int i_levels = 1;
+        // Scale the parent hierarchy and check types.
+        while (currentNodeFromAction != null && i_levels <= parentLevel) {
+            String typeOfNode = getNodeLabelFromCtElement(currentNodeFromAction);
+            String valueOfNode = currentNodeFromAction.toString();
+            String roleInParent = (currentNodeFromAction.getRoleInParent() != null)
+                    ? currentNodeFromAction.getRoleInParent().toString().toLowerCase()
+                    : "";
+
+            String patternEntityValue = (matchnewvalue) ? parentEntity.getNewValue() : parentEntity.getOldValue();
+            if ( // type of element
+                    ("*".equals(parentEntity.getEntityType())
+                            || (typeOfNode != null && typeOfNode.equals(parentEntity.getEntityType())))
+                            ///
+                            &&
+                            // value of element
+                            ("*".equals(patternEntityValue) || (valueOfNode != null && valueOfNode.equals(patternEntityValue)))
+                            //
+                            &&
+                            // role
+                            ("*".equals(parentEntity.getRoleInParent()) || (roleInParent != null
+                                    && roleInParent.equals(parentEntity.getRoleInParent().toLowerCase())))) {
+                MatchingEntity match = new MatchingEntity(currentNodeFromAction, parentEntity);
+                matching.add(match);
+
+                ParentPatternEntity parentEntityFromPattern = parentEntity.getParentPatternEntity();
+                if (parentEntityFromPattern == null) {
+                    return matching;
+                }
+                i_levels = 1;
+                parentLevel = parentEntityFromPattern.getParentLevel();
+                parentEntity = parentEntityFromPattern.getParent();
+
+            } else {
+                // Not match
+                i_levels++;
+            }
+            currentNodeFromAction = currentNodeFromAction.getParent();
+        }
+        // Not all matched
+        return null;
+
+    }
+
+    private boolean matchActionTypes(Action action, ActionType type) {
+
+        return ActionType.ANY.equals(type) || ActionType.UNCHANGED.equals(type)
+                || ActionType.UNCHANGED_HIGH_PRIORITY.equals(type)
+                || (type.equals(ActionType.INS) && (action instanceof Insert))
+                || (type.equals(ActionType.DEL) && (action instanceof Delete))
+                || (type.equals(ActionType.MOV) && (action instanceof Move))
+                || (type.equals(ActionType.UPD) && (action instanceof Update));
+    }
+
+    public ActionType getOperationType(PatternAction patternAction) {
+        return patternAction.getAction();
+    }
+
+    public String getTypeLabel(PatternAction patternAction) {
+        return patternAction.getAffectedEntity().getEntityType();
+    }
+
+    /**
+     * The label of a CtElement is the simple name of the class without the CT
+     * prefix.
+     *
+     * @param element
+     * @return
+     */
+    public String getNodeLabelFromCtElement(CtElement element) {
+        String typeFromCt = element.getClass().getSimpleName();
+        if (typeFromCt.trim().isEmpty())
+            return typeFromCt;
+        return typeFromCt.substring(2, typeFromCt.length() - 4);
+    }
 
 }

--- a/src/main/java/fr/inria/coming/changeminer/analyzer/instancedetector/ResultMapping.java
+++ b/src/main/java/fr/inria/coming/changeminer/analyzer/instancedetector/ResultMapping.java
@@ -1,6 +1,7 @@
 package fr.inria.coming.changeminer.analyzer.instancedetector;
 
 import java.util.List;
+import java.util.Set;
 
 import fr.inria.coming.changeminer.analyzer.patternspecification.PatternAction;
 import fr.inria.coming.utils.MapList;

--- a/src/main/java/fr/inria/coming/repairability/JSONRepairabilityOutput.java
+++ b/src/main/java/fr/inria/coming/repairability/JSONRepairabilityOutput.java
@@ -11,6 +11,7 @@ import fr.inria.coming.changeminer.analyzer.instancedetector.PatternInstancesFro
 import fr.inria.coming.changeminer.analyzer.patternspecification.PatternAction;
 import fr.inria.coming.core.entities.RevisionResult;
 import fr.inria.coming.core.entities.output.JSonPatternInstanceOutput;
+import fr.inria.coming.main.ComingProperties;
 import gumtree.spoon.diff.operations.Operation;
 import org.apache.log4j.Logger;
 
@@ -27,9 +28,13 @@ public class JSONRepairabilityOutput extends JSonPatternInstanceOutput {
             revisionIdentifier = revisionResult.getRelatedRevision().getName();
         }
 
-        PatternInstancesFromRevision result = (PatternInstancesFromRevision) revisionResult
-                .getResultFromClass(PatternInstanceAnalyzer.class);
-
+        PatternInstancesFromRevision result = null;
+        if(ComingProperties.getPropertyBoolean("print_only_repair_results")) {
+            result = (PatternInstancesFromRevision) revisionResult.getResultFromClass(RepairabilityAnalyzer.class);
+        }
+        else {
+            result = (PatternInstancesFromRevision) revisionResult.getResultFromClass(PatternInstanceAnalyzer.class);
+        }
         for (PatternInstancesFromDiff pi : result.getInfoPerDiff()) {
             if (pi.getInstances().size() > 0) {
 

--- a/src/main/java/fr/inria/coming/repairability/RepairabilityAnalyzer.java
+++ b/src/main/java/fr/inria/coming/repairability/RepairabilityAnalyzer.java
@@ -83,6 +83,7 @@ public class RepairabilityAnalyzer implements Analyzer {
             }
 
             // modify this PatternInstancesFromDiff to contain only filtered elements
+            // FIXME: this also changes PatternInstanceAnalyzer result
             instancesPerDiff.setInstances(patternInstanceList);
 
             allInstances.add(instancesPerDiff);
@@ -94,10 +95,10 @@ public class RepairabilityAnalyzer implements Analyzer {
     }
 
     private boolean coversTheWholeDiff(ChangePatternInstance instancePattern, Diff diff) {
-        for(Operation diffOperation : diff.getAllOperations()){
+        for(Operation diffOperation : diff.getRootOperations()){
             boolean foundOp = false;
             for(Operation instanceOperation : instancePattern.getActions()){
-                if(diffOperation.toString().equals(instanceOperation.toString())){
+                if(diffOperation.equals(instanceOperation)){
                     foundOp = true;
                     break;
                 }

--- a/src/main/java/fr/inria/coming/repairability/RepairabilityAnalyzer.java
+++ b/src/main/java/fr/inria/coming/repairability/RepairabilityAnalyzer.java
@@ -68,9 +68,13 @@ public class RepairabilityAnalyzer implements Analyzer {
 
                     if (!toolsSeen.contains(toolName)
                             || ComingProperties.getPropertyBoolean("include_all_instances_for_each_tool")) {
+                        /* ignore if the tool has been seen before and
+                           the "include_all_instances_for_each_tool" is not used */
                         if(!ComingProperties.getPropertyBoolean("exclude_repair_patterns_not_covering_the_whole_diff")
                                 || coversTheWholeDiff(instancePattern, instancesPerDiff.getDiff())) {
-                            //add instance of single repair tool only once
+                            /* ignore if the found instances do not cover the whole diff and
+                                "exclude_repair_patterns_not_covering_the_whole_diff" is used
+                             */
                             patternInstanceList.add(instancePattern);
                             toolsSeen.add(toolName);
                         }

--- a/src/main/java/fr/inria/coming/repairability/repairtools/AbstractRepairTool.java
+++ b/src/main/java/fr/inria/coming/repairability/repairtools/AbstractRepairTool.java
@@ -71,7 +71,7 @@ public abstract class AbstractRepairTool {
 
     public String getPathFromResources(String name) {
         String rootInputFile = "/repairability/" + this.getClass().getSimpleName() + "/" + name;
-        String outFile = "/tmp/" + this.getClass().getSimpleName() + name;
+        String outFilePath = null;
         try {
             // read the file into buffer
             InputStream inputStream = this.getClass().getResourceAsStream(rootInputFile);
@@ -80,13 +80,15 @@ public abstract class AbstractRepairTool {
             inputStream.close();
 
             // make a tmp file
-            OutputStream outStream = new FileOutputStream(outFile);
+            File outFile = File.createTempFile("tmp-" + this.getClass().getSimpleName() + name, null);
+            outFilePath = outFile.getPath();
+            OutputStream outStream = new FileOutputStream(outFilePath);
             outStream.write(buffer);
             outStream.close();
         } catch (Exception e) {
             e.printStackTrace();
             System.exit(1);
         }
-        return outFile;
+        return outFilePath;
     }
 }

--- a/src/main/resources/repairability_test_files/exclude_not_covering/covered/covered/covered_covered_s.java
+++ b/src/main/resources/repairability_test_files/exclude_not_covering/covered/covered/covered_covered_s.java
@@ -1,0 +1,353 @@
+package javarepl;
+
+import com.googlecode.totallylazy.*;
+import com.googlecode.totallylazy.Option;
+import com.googlecode.totallylazy.annotations.multimethod;
+import com.googlecode.totallylazy.functions.Reducer;
+import javarepl.expressions.*;
+import javarepl.expressions.Value;
+
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.regex.MatchResult;
+
+import static com.googlecode.totallylazy.Either.left;
+import static com.googlecode.totallylazy.Either.right;
+import static com.googlecode.totallylazy.Files.*;
+import static com.googlecode.totallylazy.Option.*;
+import static com.googlecode.totallylazy.Sequences.empty;
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.totallylazy.predicates.Not.not;
+import static com.googlecode.totallylazy.predicates.Predicates.equalTo;
+import static com.googlecode.totallylazy.predicates.Predicates.where;
+import static java.io.File.pathSeparator;
+import static javarepl.Evaluation.evaluation;
+import static javarepl.EvaluationClassLoader.evaluationClassLoader;
+import static javarepl.EvaluationContext.evaluationContext;
+import static javarepl.Result.noResult;
+import static javarepl.Utils.randomIdentifier;
+import static javarepl.Utils.urlAsFilePath;
+import static javarepl.expressions.Patterns.*;
+import static javarepl.rendering.EvaluationClassRenderer.renderExpressionClass;
+import static javarepl.rendering.EvaluationClassRenderer.renderMethodSignatureDetection;
+import static javarepl.rendering.ExpressionSourceRenderer.renderExpressionSource;
+import static javarepl.rendering.ExpressionTokenRenderer.EXPRESSION_TOKEN;
+import static javax.tools.ToolProvider.getSystemJavaCompiler;
+
+public class Evaluator {
+
+    private EvaluationClassLoader classLoader;
+    private EvaluationContext context;
+
+    public Evaluator() {
+        initializeEvaluator(evaluationContext());
+    }
+
+    private Evaluator(EvaluationContext context) {
+        initializeEvaluator(context);
+    }
+
+    public Either<Throwable, Evaluation> evaluate(final String expr) {
+        return parseExpression(expr).flatMap(
+                expression -> {
+                    Either<Throwable, Evaluation> resultForValue = evaluate(expression);
+                    if (resultForValue.isLeft() && resultForValue.left() instanceof ExpressionCompilationException && expression instanceof Value) {
+                        Either<Throwable, Evaluation> resultForStatement = evaluate(new Statement(expr));
+                        return resultForStatement.isLeft() && resultForStatement.left() instanceof ExpressionCompilationException
+                                ? left(new ExpressionCompilationException(sequence(resultForStatement.left().getMessage(), resultForValue.left().getMessage()).unique().toString("\n\n")))
+                                : resultForStatement;
+                    }
+
+                    return resultForValue;
+                });
+    }
+
+    public Either<Throwable, Expression> parseExpression(String expression) {
+        if (isValidImport(expression))
+            return createImport(expression);
+
+        if (isValidType(expression))
+            return createTypeExpression(expression);
+
+        if (isValidMethod(expression))
+            return createMethodExpression(expression);
+
+        if (isValidAssignmentWithType(expression))
+            return createAssignmentWithType(expression);
+
+        if (isValidAssignment(expression))
+            return createAssignmentExpression(expression);
+
+        return createValueExpression(expression);
+    }
+
+    public void addResults(Sequence<Result> result) {
+        context = context.addResults(result);
+    }
+
+    private Either<Throwable, Expression> createImport(String expression) {
+        return right((Expression) new Import(expression, importPattern.match(expression).group(1)));
+    }
+
+    private Either<Throwable, Expression> createAssignmentWithType(String expression) {
+        try {
+            MatchResult match = Patterns.assignmentWithTypeNamePattern.match(expression);
+            java.lang.reflect.Method declaredMethod = detectMethod(match.group(1) + " " + randomIdentifier("method") + "(){}");
+            return right((Expression) new AssignmentWithType(expression, declaredMethod.getGenericReturnType(), match.group(2), match.group(3)));
+        } catch (Exception e) {
+            return left(Utils.unwrapException(e));
+        }
+    }
+
+    private Either<Throwable, Expression> createAssignmentExpression(String expression) {
+        MatchResult match = Patterns.assignmentPattern.match(expression);
+        return right((Expression) new Assignment(expression, match.group(1), match.group(2)));
+    }
+
+    private Either<Throwable, Expression> createTypeExpression(String expression) {
+        MatchResult match = typePattern.match(expression);
+        return right((Expression) new Type(expression, option(match.group(1)), match.group(2)));
+    }
+
+    private Either<Throwable, Expression> createValueExpression(String expression) {
+        return right((Expression) new Value(expression));
+    }
+
+    public Option<String> lastSource() {
+        return context.lastSource();
+    }
+
+    public Sequence<Result> results() {
+        return context.results();
+    }
+
+    public Option<Result> result(String name) {
+        return context.result(name);
+    }
+
+    public <T extends Expression> Sequence<T> expressionsOfType(Class<T> type) {
+        return context.expressionsOfType(type);
+    }
+
+    public Sequence<Expression> expressions() {
+        return context.expressions();
+    }
+
+    public EvaluationContext context() {
+        return context;
+    }
+
+    public void reset() {
+        clearOutputDirectory();
+        initializeEvaluator(evaluationContext());
+    }
+
+    private void initializeEvaluator(EvaluationContext evaluationContext) {
+        context = evaluationContext;
+        classLoader = evaluationClassLoader(context.outputDirectory());
+    }
+
+    public final Either<Throwable, Evaluation> tryEvaluate(String expression) {
+        Evaluator localEvaluator = new Evaluator(context);
+        return localEvaluator.evaluate(expression);
+    }
+
+    public final Option<java.lang.reflect.Type> typeOfExpression(String expression) {
+        Either<? extends Throwable, Evaluation> evaluation = tryEvaluate(expression);
+
+        Option<java.lang.reflect.Type> expressionType = none();
+        if (evaluation.isRight()) {
+            Option<Result> result = evaluation.right().result();
+            if (!result.isEmpty()) {
+                expressionType = some(result.get().type());
+            }
+        }
+
+        return expressionType;
+    }
+
+    public final Option<Class> classFrom(String expression) {
+        try {
+            return some(detectClass(expression));
+        } catch (Throwable e) {
+            return none();
+        }
+    }
+
+    public void clearOutputDirectory() {
+        deleteFiles(context.outputDirectory());
+        delete(context.outputDirectory());
+    }
+
+    public void addClasspathUrl(URL classpathUrl) {
+        classLoader.addURL(classpathUrl);
+    }
+
+    public File outputDirectory() {
+        return context.outputDirectory();
+    }
+
+    @multimethod
+    private Either<Throwable, Evaluation> evaluate(Expression expression) {
+        return new multi() {
+        }.<Either<Throwable, Evaluation>>methodOption(expression).getOrElse(evaluateExpression(expression));
+    }
+
+    @multimethod
+    private Either<Throwable, Evaluation> evaluate(Type expression) {
+        if (getSystemJavaCompiler() == null) {
+            return left((Throwable) new FileNotFoundException("Java compiler not found." +
+                    "This can occur when JavaREPL was run with JRE instead of JDK or JDK is not configured correctly."));
+        }
+
+        try {
+            File outputPath = directory(context.outputDirectory(), expression.typePackage().getOrElse("").replace('.', File.separatorChar));
+            File outputJavaFile = file(outputPath, expression.type() + ".java");
+
+            String sources = renderExpressionClass(context, expression.type(), expression)
+                    .replace(EXPRESSION_TOKEN, renderExpressionSource(expression));
+
+            Files.write(sources.getBytes(), outputJavaFile);
+            compile(outputJavaFile);
+
+            classLoader.loadClass(expression.canonicalName());
+
+            context = context.addExpression(expression).lastSource(sources);
+
+            return right(evaluation(expression, noResult()));
+        } catch (Exception e) {
+            return left(Utils.unwrapException(e));
+        }
+    }
+
+    private Either<Throwable, Expression> createMethodExpression(String expression) {
+        try {
+            java.lang.reflect.Method declaredMethod = detectMethod(expression);
+            return right((Expression) new Method(expression, declaredMethod.getGenericReturnType(), declaredMethod.getName(), sequence(declaredMethod.getParameterTypes())));
+        } catch (Exception e) {
+            return left(Utils.unwrapException(e));
+        }
+    }
+
+    private java.lang.reflect.Method detectMethod(String expression) throws Exception {
+        final String className = randomIdentifier("Method");
+        final File outputJavaFile = file(context.outputDirectory(), className + ".java");
+
+        final String sources = renderMethodSignatureDetection(context, className, expression);
+        Files.write(sources.getBytes(), outputJavaFile);
+
+        compile(outputJavaFile);
+
+        Class<?> expressionClass = classLoader.loadClass(className);
+
+        return expressionClass.getDeclaredMethods()[0];
+    }
+
+    private Class detectClass(String expression) throws Exception {
+        final String className = randomIdentifier("Class");
+        final File outputJavaFile = file(context.outputDirectory(), className + ".java");
+
+        final String sources = renderMethodSignatureDetection(context, className, "public " + expression + " detectClass(){return null;}");
+        Files.write(sources.getBytes(), outputJavaFile);
+
+        compile(outputJavaFile);
+
+        Class expressionClass = classLoader.loadClass(className);
+
+        return expressionClass.getDeclaredMethods()[0].getReturnType();
+    }
+
+    private Either<Throwable, Evaluation> evaluateExpression(final Expression expression) {
+        final String className = randomIdentifier("Evaluation");
+
+        try {
+            EvaluationContext newContext = context.removeExpressionWithKey(expression.key());
+
+            File outputJavaFile = file(context.outputDirectory(), className + ".java");
+            final String sources = renderExpressionClass(newContext, className, expression)
+                    .replace(EXPRESSION_TOKEN, renderExpressionSource(expression));
+
+            Files.write(sources.getBytes(), outputJavaFile);
+
+            compile(outputJavaFile);
+
+            Class<?> expressionClass = classLoader.loadClass(className);
+            Constructor<?> constructor = expressionClass.getDeclaredConstructor(EvaluationContext.class);
+
+            final Object expressionInstance = constructor.newInstance(newContext);
+
+            java.lang.reflect.Method method = expressionClass.getMethod("evaluate");
+            Object resultObject = method.invoke(expressionInstance);
+
+            Sequence<Result> modifiedResults = modifiedResults(expressionInstance);
+
+            if (resultObject != null || !method.getReturnType().equals(void.class)) {
+                Result result = Result.result(nextResultKeyFor(expression), resultObject, typeFor(expression));
+                context = newContext.addExpression(expression).addResults(modifiedResults.append(result)).lastSource(sources);
+                return right(evaluation(expression, some(result)));
+            } else {
+                context = newContext.addExpression(expression).addResults(modifiedResults).lastSource(sources);
+                return right(evaluation(expression, noResult()));
+            }
+        } catch (Throwable e) {
+            return left(Utils.unwrapException(e));
+        }
+    }
+
+    private Sequence<Result> modifiedResults(final Object expressionInstance) {
+        return sequence(expressionInstance.getClass().getDeclaredFields())
+                .reduceLeft(new Reducer<Field, Sequence<Result>>() {
+                    public Sequence<Result> call(Sequence<Result> results, Field field) throws Exception {
+                        Option<Result> result = result(field.getName()).filter(where(Result::value, not(equalTo(field.get(expressionInstance)))));
+
+                        if (result.isEmpty())
+                            return results;
+
+                        return results.append(Result.result(field.getName(), field.get(expressionInstance)));
+
+                    }
+
+                    public Sequence<Result> identity() {
+                        return empty(Result.class);
+                    }
+                });
+    }
+
+    private String nextResultKeyFor(Expression expression) {
+        return (expression instanceof Value)
+                ? context.nextResultKey()
+                : expression.key();
+    }
+
+    private Option<java.lang.reflect.Type> typeFor(Expression expression) {
+        return (expression instanceof AssignmentWithType)
+                ? Option.some(((AssignmentWithType) expression).type())
+                : Option.<java.lang.reflect.Type>none();
+    }
+
+    private void compile(File file) throws Exception {
+        String classpath =
+                sequence(System.getProperty("java.class.path"))
+                        .join(sequence(classLoader.getURLs()).map(urlAsFilePath()))
+                        .toString(pathSeparator);
+        JavaCompiler compiler = getSystemJavaCompiler();
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
+        StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, null, null);
+        Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(sequence(file));
+        JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, sequence("-cp", classpath), null, compilationUnits);
+
+        try {
+            if (!task.call())
+                throw new ExpressionCompilationException(file, diagnostics.getDiagnostics());
+        } finally {
+            fileManager.close();
+        }
+    }
+}

--- a/src/main/resources/repairability_test_files/exclude_not_covering/covered/covered/covered_covered_t.java
+++ b/src/main/resources/repairability_test_files/exclude_not_covering/covered/covered/covered_covered_t.java
@@ -1,0 +1,354 @@
+package javarepl;
+
+import com.googlecode.totallylazy.*;
+import com.googlecode.totallylazy.Option;
+import com.googlecode.totallylazy.annotations.multimethod;
+import com.googlecode.totallylazy.functions.Reducer;
+import javarepl.expressions.*;
+import javarepl.expressions.Type;
+import javarepl.expressions.Value;
+
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.regex.MatchResult;
+
+import static com.googlecode.totallylazy.Either.left;
+import static com.googlecode.totallylazy.Either.right;
+import static com.googlecode.totallylazy.Files.*;
+import static com.googlecode.totallylazy.Option.*;
+import static com.googlecode.totallylazy.Sequences.empty;
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.totallylazy.predicates.Not.not;
+import static com.googlecode.totallylazy.predicates.Predicates.equalTo;
+import static com.googlecode.totallylazy.predicates.Predicates.where;
+import static java.io.File.pathSeparator;
+import static javarepl.Evaluation.evaluation;
+import static javarepl.EvaluationClassLoader.evaluationClassLoader;
+import static javarepl.EvaluationContext.evaluationContext;
+import static javarepl.Result.noResult;
+import static javarepl.Utils.randomIdentifier;
+import static javarepl.Utils.urlAsFilePath;
+import static javarepl.expressions.Patterns.*;
+import static javarepl.rendering.EvaluationClassRenderer.renderExpressionClass;
+import static javarepl.rendering.EvaluationClassRenderer.renderMethodSignatureDetection;
+import static javarepl.rendering.ExpressionSourceRenderer.renderExpressionSource;
+import static javarepl.rendering.ExpressionTokenRenderer.EXPRESSION_TOKEN;
+import static javax.tools.ToolProvider.getSystemJavaCompiler;
+
+public class Evaluator {
+
+    private EvaluationClassLoader classLoader;
+    private EvaluationContext context;
+
+    public Evaluator() {
+        initializeEvaluator(evaluationContext());
+    }
+
+    private Evaluator(EvaluationContext context) {
+        initializeEvaluator(context);
+    }
+
+    public Either<Throwable, Evaluation> evaluate(final String expr) {
+        return parseExpression(expr).flatMap(
+                expression -> {
+                    Either<Throwable, Evaluation> resultForValue = evaluate(expression);
+                    if (resultForValue.isLeft() && resultForValue.left() instanceof ExpressionCompilationException && expression instanceof Value) {
+                        Either<Throwable, Evaluation> resultForStatement = evaluate(new Statement(expr));
+                        return resultForStatement.isLeft() && resultForStatement.left() instanceof ExpressionCompilationException
+                                ? left(new ExpressionCompilationException(sequence(resultForStatement.left().getMessage(), resultForValue.left().getMessage()).unique().toString("\n\n")))
+                                : resultForStatement;
+                    }
+
+                    return resultForValue;
+                });
+    }
+
+    public Either<Throwable, Expression> parseExpression(String expression) {
+        if (isValidImport(expression))
+            return createImport(expression);
+
+        if (isValidType(expression))
+            return createTypeExpression(expression);
+
+        if (isValidMethod(expression))
+            return createMethodExpression(expression);
+
+        if (isValidAssignmentWithType(expression))
+            return createAssignmentWithType(expression);
+
+        if (isValidAssignment(expression))
+            return createAssignmentExpression(expression);
+
+        return createValueExpression(expression);
+    }
+
+    public void addResults(Sequence<Result> result) {
+        context = context.addResults(result);
+    }
+
+    private Either<Throwable, Expression> createImport(String expression) {
+        return right((Expression) new Import(expression, importPattern.match(expression).group(1)));
+    }
+
+    private Either<Throwable, Expression> createAssignmentWithType(String expression) {
+        try {
+            MatchResult match = Patterns.assignmentWithTypeNamePattern.match(expression);
+            java.lang.reflect.Method declaredMethod = detectMethod(match.group(1) + " " + randomIdentifier("method") + "(){}");
+            return right((Expression) new AssignmentWithType(expression, declaredMethod.getGenericReturnType(), match.group(2), match.group(3)));
+        } catch (Exception e) {
+            return left(Utils.unwrapException(e));
+        }
+    }
+
+    private Either<Throwable, Expression> createAssignmentExpression(String expression) {
+        MatchResult match = Patterns.assignmentPattern.match(expression);
+        return right((Expression) new Assignment(expression, match.group(1), match.group(2)));
+    }
+
+    private Either<Throwable, Expression> createTypeExpression(String expression) {
+        MatchResult match = typePattern.match(expression);
+        return right((Expression) new Type(expression, option(match.group(1)), match.group(2)));
+    }
+
+    private Either<Throwable, Expression> createValueExpression(String expression) {
+        return right((Expression) new Value(expression));
+    }
+
+    public Option<String> lastSource() {
+        return context.lastSource();
+    }
+
+    public Sequence<Result> results() {
+        return context.results();
+    }
+
+    public Option<Result> result(String name) {
+        return context.result(name);
+    }
+
+    public <T extends Expression> Sequence<T> expressionsOfType(Class<T> type) {
+        return context.expressionsOfType(type);
+    }
+
+    public Sequence<Expression> expressions() {
+        return context.expressions();
+    }
+
+    public EvaluationContext context() {
+        return context;
+    }
+
+    public void reset() {
+        clearOutputDirectory();
+        initializeEvaluator(evaluationContext());
+    }
+
+    private void initializeEvaluator(EvaluationContext evaluationContext) {
+        context = evaluationContext;
+        classLoader = evaluationClassLoader(context.outputDirectory());
+    }
+
+    public final Either<Throwable, Evaluation> tryEvaluate(String expression) {
+        Evaluator localEvaluator = new Evaluator(context);
+        return localEvaluator.evaluate(expression);
+    }
+
+    public final Option<java.lang.reflect.Type> typeOfExpression(String expression) {
+        Either<? extends Throwable, Evaluation> evaluation = tryEvaluate(expression);
+
+        Option<java.lang.reflect.Type> expressionType = none();
+        if (evaluation.isRight()) {
+            Option<Result> result = evaluation.right().result();
+            if (!result.isEmpty()) {
+                expressionType = some(result.get().type());
+            }
+        }
+
+        return expressionType;
+    }
+
+    public final Option<Class> classFrom(String expression) {
+        try {
+            return some(detectClass(expression));
+        } catch (Throwable e) {
+            return none();
+        }
+    }
+
+    public void clearOutputDirectory() {
+        deleteFiles(context.outputDirectory());
+        delete(context.outputDirectory());
+    }
+
+    public void addClasspathUrl(URL classpathUrl) {
+        classLoader.addURL(classpathUrl);
+    }
+
+    public File outputDirectory() {
+        return context.outputDirectory();
+    }
+
+    @multimethod
+    private Either<Throwable, Evaluation> evaluate(Expression expression) {
+        return new multi() {
+        }.<Either<Throwable, Evaluation>>methodOption(expression).getOrElse(evaluateExpression(expression));
+    }
+
+    @multimethod
+    private Either<Throwable, Evaluation> evaluate(Type expression) {
+        if (getSystemJavaCompiler() == null) {
+            return left((Throwable) new FileNotFoundException("Java compiler not found." +
+                    "This can occur when JavaREPL was run with JRE instead of JDK or JDK is not configured correctly."));
+        }
+
+        try {
+            File outputPath = directory(context.outputDirectory(), expression.typePackage().getOrElse("").replace('.', File.separatorChar));
+            File outputJavaFile = file(outputPath, expression.type() + ".java");
+
+            String sources = renderExpressionClass(context, expression.type(), expression)
+                    .replace(EXPRESSION_TOKEN, renderExpressionSource(expression));
+
+            Files.write(sources.getBytes(), outputJavaFile);
+            compile(outputJavaFile);
+
+            classLoader.loadClass(expression.canonicalName());
+
+            context = context.addExpression(expression).lastSource(sources);
+
+            return right(evaluation(expression, noResult()));
+        } catch (Exception e) {
+            return left(Utils.unwrapException(e));
+        }
+    }
+
+    private Either<Throwable, Expression> createMethodExpression(String expression) {
+        try {
+            java.lang.reflect.Method declaredMethod = detectMethod(expression);
+            return right((Expression) new Method(expression, declaredMethod.getGenericReturnType(), declaredMethod.getName(), sequence(declaredMethod.getParameterTypes())));
+        } catch (Exception e) {
+            return left(Utils.unwrapException(e));
+        }
+    }
+
+    private java.lang.reflect.Method detectMethod(String expression) throws Exception {
+        final String className = randomIdentifier("Method");
+        final File outputJavaFile = file(context.outputDirectory(), className + ".java");
+
+        final String sources = renderMethodSignatureDetection(context, className, expression);
+        Files.write(sources.getBytes(), outputJavaFile);
+
+        compile(outputJavaFile);
+
+        Class<?> expressionClass = classLoader.loadClass(className);
+
+        return expressionClass.getDeclaredMethods()[0];
+    }
+
+    private Class detectClass(String expression) throws Exception {
+        final String className = randomIdentifier("Class");
+        final File outputJavaFile = file(context.outputDirectory(), className + ".java");
+
+        final String sources = renderMethodSignatureDetection(context, className, "public " + expression + " detectClass(){return null;}");
+        Files.write(sources.getBytes(), outputJavaFile);
+
+        compile(outputJavaFile);
+
+        Class expressionClass = classLoader.loadClass(className);
+
+        return expressionClass.getDeclaredMethods()[0].getReturnType();
+    }
+
+    private Either<Throwable, Evaluation> evaluateExpression(final Expression expression) {
+        final String className = randomIdentifier("Evaluation");
+
+        try {
+            EvaluationContext newContext = context.removeExpressionWithKey(expression.key());
+
+            File outputJavaFile = file(context.outputDirectory(), className + ".java");
+            final String sources = renderExpressionClass(newContext, className, expression)
+                    .replace(EXPRESSION_TOKEN, renderExpressionSource(expression));
+
+            Files.write(sources.getBytes(), outputJavaFile);
+
+            compile(outputJavaFile);
+
+            Class<?> expressionClass = classLoader.loadClass(className);
+            Constructor<?> constructor = expressionClass.getDeclaredConstructor(EvaluationContext.class);
+
+            final Object expressionInstance = constructor.newInstance(newContext);
+
+            java.lang.reflect.Method method = expressionClass.getMethod("evaluate");
+            Object resultObject = method.invoke(expressionInstance);
+
+            Sequence<Result> modifiedResults = modifiedResults(expressionInstance);
+
+            if (resultObject != null || !method.getReturnType().equals(void.class)) {
+                Result result = Result.result(nextResultKeyFor(expression), resultObject, typeFor(expression));
+                context = newContext.addExpression(expression).addResults(modifiedResults.append(result)).lastSource(sources);
+                return right(evaluation(expression, some(result)));
+            } else {
+                context = newContext.addExpression(expression).addResults(modifiedResults).lastSource(sources);
+                return right(evaluation(expression, noResult()));
+            }
+        } catch (Throwable e) {
+            return left(Utils.unwrapException(e));
+        }
+    }
+
+    private Sequence<Result> modifiedResults(final Object expressionInstance) {
+        return sequence(expressionInstance.getClass().getDeclaredFields())
+                .reduceLeft(new Reducer<Field, Sequence<Result>>() {
+                    public Sequence<Result> call(Sequence<Result> results, Field field) throws Exception {
+                        Option<Result> result = result(field.getName()).filter(where(Result::value, not(equalTo(field.get(expressionInstance)))));
+
+                        if (result.isEmpty())
+                            return results;
+
+                        return results.append(Result.result(field.getName(), field.get(expressionInstance)));
+
+                    }
+
+                    public Sequence<Result> identity() {
+                        return empty(Result.class);
+                    }
+                });
+    }
+
+    private String nextResultKeyFor(Expression expression) {
+        return (expression instanceof Value)
+                ? context.nextResultKey()
+                : expression.key();
+    }
+
+    private Option<java.lang.reflect.Type> typeFor(Expression expression) {
+        return (expression instanceof AssignmentWithType)
+                ? Option.some(((AssignmentWithType) expression).type())
+                : Option.<java.lang.reflect.Type>none();
+    }
+
+    private void compile(File file) throws Exception {
+        String classpath =
+                sequence(System.getProperty("java.class.path"))
+                        .join(sequence(classLoader.getURLs()).map(urlAsFilePath()))
+                        .toString(pathSeparator);
+        JavaCompiler compiler = getSystemJavaCompiler();
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
+        StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, null, null);
+        Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(sequence(file));
+        JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, sequence("-cp", classpath), null, compilationUnits);
+
+        try {
+            if (!task.call())
+                throw new ExpressionCompilationException(file, diagnostics.getDiagnostics());
+        } finally {
+            fileManager.close();
+        }
+    }
+}

--- a/src/main/resources/repairability_test_files/exclude_not_covering/not_covered/not_covered/not_covered_not_covered_s.java
+++ b/src/main/resources/repairability_test_files/exclude_not_covering/not_covered/not_covered/not_covered_not_covered_s.java
@@ -1,0 +1,207 @@
+package com.actionbarsherlock.internal.view.menu;
+
+import java.util.WeakHashMap;
+
+import android.content.ComponentName;
+import android.content.Intent;
+import android.view.KeyEvent;
+
+import com.actionbarsherlock.view.Menu;
+import com.actionbarsherlock.view.MenuItem;
+import com.actionbarsherlock.view.SubMenu;
+
+public class MenuWrapper implements Menu {
+    private final android.view.Menu mNativeMenu;
+
+    private final WeakHashMap<android.view.MenuItem, MenuItem> mNativeMap =
+            new WeakHashMap<android.view.MenuItem, MenuItem>();
+
+
+    public MenuWrapper(android.view.Menu nativeMenu) {
+        mNativeMenu = nativeMenu;
+    }
+
+    public android.view.Menu unwrap() {
+        return mNativeMenu;
+    }
+
+    private MenuItem addInternal(android.view.MenuItem nativeItem) {
+        MenuItem item = new MenuItemWrapper(nativeItem);
+        mNativeMap.put(nativeItem, item);
+        return item;
+    }
+
+    @Override
+    public MenuItem add(CharSequence title) {
+        return addInternal(mNativeMenu.add(title));
+    }
+
+    @Override
+    public MenuItem add(int titleRes) {
+        return addInternal(mNativeMenu.add(titleRes));
+    }
+
+    @Override
+    public MenuItem add(int groupId, int itemId, int order, CharSequence title) {
+        return addInternal(mNativeMenu.add(groupId, itemId, order, title));
+    }
+
+    @Override
+    public MenuItem add(int groupId, int itemId, int order, int titleRes) {
+        return addInternal(mNativeMenu.add(groupId, itemId, order, titleRes));
+    }
+
+    private SubMenu addInternal(android.view.SubMenu nativeSubMenu) {
+        SubMenu subMenu = new SubMenuWrapper(nativeSubMenu);
+        android.view.MenuItem nativeItem = nativeSubMenu.getItem();
+        MenuItem item = subMenu.getItem();
+        mNativeMap.put(nativeItem, item);
+        return subMenu;
+    }
+
+    @Override
+    public SubMenu addSubMenu(CharSequence title) {
+        return addInternal(mNativeMenu.addSubMenu(title));
+    }
+
+    @Override
+    public SubMenu addSubMenu(int titleRes) {
+        return addInternal(mNativeMenu.addSubMenu(titleRes));
+    }
+
+    @Override
+    public SubMenu addSubMenu(int groupId, int itemId, int order, CharSequence title) {
+        return addInternal(mNativeMenu.addSubMenu(groupId, itemId, order, title));
+    }
+
+    @Override
+    public SubMenu addSubMenu(int groupId, int itemId, int order, int titleRes) {
+        return addInternal(mNativeMenu.addSubMenu(groupId, itemId, order, titleRes));
+    }
+
+    @Override
+    public int addIntentOptions(int groupId, int itemId, int order, ComponentName caller, Intent[] specifics, Intent intent, int flags, MenuItem[] outSpecificItems) {
+        int result;
+        if (outSpecificItems != null) {
+            android.view.MenuItem[] nativeOutItems = new android.view.MenuItem[outSpecificItems.length];
+            result = mNativeMenu.addIntentOptions(groupId, itemId, order, caller, specifics, intent, flags, nativeOutItems);
+            for (int i = 0, length = outSpecificItems.length; i < length; i++) {
+                outSpecificItems[i] = new MenuItemWrapper(nativeOutItems[i]);
+            }
+        } else {
+            result = mNativeMenu.addIntentOptions(groupId, itemId, order, caller, specifics, intent, flags, null);
+        }
+        return result;
+    }
+
+    @Override
+    public void removeItem(int id) {
+        final android.view.MenuItem item = mNativeMenu.findItem(id);
+        mNativeMap.remove(item);
+        mNativeMenu.removeItem(id);
+    }
+
+    @Override
+    public void removeGroup(int groupId) {
+        for (int i = 0; i < mNativeMenu.size(); i++) {
+          final android.view.MenuItem item = mNativeMenu.getItem(i);
+          if (item.getGroupId() == groupId) { mNativeMap.remove(item); }
+        }
+        mNativeMenu.removeGroup(groupId);
+    }
+
+    @Override
+    public void clear() {
+        mNativeMap.clear();
+        mNativeMenu.clear();
+    }
+
+    public void invalidate() {
+        if (mNativeMap.isEmpty()) { return; }
+
+        final WeakHashMap<android.view.MenuItem, MenuItem> menuMapCopy = new WeakHashMap<android.view.MenuItem, MenuItem>(mNativeMap.size());
+
+        for (int i = 0; i < mNativeMenu.size(); i++) {
+          final android.view.MenuItem item = mNativeMenu.getItem(i);
+          menuMapCopy.put(item, mNativeMap.get(item));
+        }
+
+        mNativeMap.clear();
+        mNativeMap.putAll(menuMapCopy);
+    }
+
+    @Override
+    public void setGroupCheckable(int group, boolean checkable, boolean exclusive) {
+        mNativeMenu.setGroupCheckable(group, checkable, exclusive);
+    }
+
+    @Override
+    public void setGroupVisible(int group, boolean visible) {
+        mNativeMenu.setGroupVisible(group, visible);
+    }
+
+    @Override
+    public void setGroupEnabled(int group, boolean enabled) {
+        mNativeMenu.setGroupEnabled(group, enabled);
+    }
+
+    @Override
+    public boolean hasVisibleItems() {
+        return mNativeMenu.hasVisibleItems();
+    }
+
+    @Override
+    public MenuItem findItem(int id) {
+        android.view.MenuItem nativeItem = mNativeMenu.findItem(id);
+        return findItem(nativeItem);
+    }
+
+    public MenuItem findItem(android.view.MenuItem nativeItem) {
+        if (nativeItem == null) {
+            return null;
+        }
+
+        MenuItem wrapped = mNativeMap.get(nativeItem);
+        if (wrapped != null) {
+            return wrapped;
+        }
+
+        return addInternal(nativeItem);
+    }
+
+    @Override
+    public int size() {
+        return mNativeMenu.size();
+    }
+
+    @Override
+    public MenuItem getItem(int index) {
+        android.view.MenuItem nativeItem = mNativeMenu.getItem(index);
+        return findItem(nativeItem);
+    }
+
+    @Override
+    public void close() {
+        mNativeMenu.close();
+    }
+
+    @Override
+    public boolean performShortcut(int keyCode, KeyEvent event, int flags) {
+        return mNativeMenu.performShortcut(keyCode, event, flags);
+    }
+
+    @Override
+    public boolean isShortcutKey(int keyCode, KeyEvent event) {
+        return mNativeMenu.isShortcutKey(keyCode, event);
+    }
+
+    @Override
+    public boolean performIdentifierAction(int id, int flags) {
+        return mNativeMenu.performIdentifierAction(id, flags);
+    }
+
+    @Override
+    public void setQwertyMode(boolean isQwerty) {
+        mNativeMenu.setQwertyMode(isQwerty);
+    }
+}

--- a/src/main/resources/repairability_test_files/exclude_not_covering/not_covered/not_covered/not_covered_not_covered_t.java
+++ b/src/main/resources/repairability_test_files/exclude_not_covering/not_covered/not_covered/not_covered_not_covered_t.java
@@ -1,0 +1,204 @@
+package com.actionbarsherlock.internal.view.menu;
+
+import java.util.WeakHashMap;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.view.KeyEvent;
+import com.actionbarsherlock.view.Menu;
+import com.actionbarsherlock.view.MenuItem;
+import com.actionbarsherlock.view.SubMenu;
+
+public class MenuWrapper implements Menu {
+    private final android.view.Menu mNativeMenu;
+
+    private final WeakHashMap<android.view.MenuItem, MenuItem> mNativeMap =
+            new WeakHashMap<android.view.MenuItem, MenuItem>();
+
+
+    public MenuWrapper(android.view.Menu nativeMenu) {
+        mNativeMenu = nativeMenu;
+    }
+
+    public android.view.Menu unwrap() {
+        return mNativeMenu;
+    }
+
+    private MenuItem addInternal(android.view.MenuItem nativeItem) {
+        MenuItem item = new MenuItemWrapper(nativeItem);
+        mNativeMap.put(nativeItem, item);
+        return item;
+    }
+
+    @Override
+    public MenuItem add(CharSequence title) {
+        return addInternal(mNativeMenu.add(title));
+    }
+
+    @Override
+    public MenuItem add(int titleRes) {
+        return addInternal(mNativeMenu.add(titleRes));
+    }
+
+    @Override
+    public MenuItem add(int groupId, int itemId, int order, CharSequence title) {
+        return addInternal(mNativeMenu.add(groupId, itemId, order, title));
+    }
+
+    @Override
+    public MenuItem add(int groupId, int itemId, int order, int titleRes) {
+        return addInternal(mNativeMenu.add(groupId, itemId, order, titleRes));
+    }
+
+    private SubMenu addInternal(android.view.SubMenu nativeSubMenu) {
+        SubMenu subMenu = new SubMenuWrapper(nativeSubMenu);
+        android.view.MenuItem nativeItem = nativeSubMenu.getItem();
+        MenuItem item = subMenu.getItem();
+        mNativeMap.put(nativeItem, item);
+        return subMenu;
+    }
+
+    @Override
+    public SubMenu addSubMenu(CharSequence title) {
+        return addInternal(mNativeMenu.addSubMenu(title));
+    }
+
+    @Override
+    public SubMenu addSubMenu(int titleRes) {
+        return addInternal(mNativeMenu.addSubMenu(titleRes));
+    }
+
+    @Override
+    public SubMenu addSubMenu(int groupId, int itemId, int order, CharSequence title) {
+        return addInternal(mNativeMenu.addSubMenu(groupId, itemId, order, title));
+    }
+
+    @Override
+    public SubMenu addSubMenu(int groupId, int itemId, int order, int titleRes) {
+        return addInternal(mNativeMenu.addSubMenu(groupId, itemId, order, titleRes));
+    }
+
+    @Override
+    public int addIntentOptions(int groupId, int itemId, int order, ComponentName caller, Intent[] specifics, Intent intent, int flags, MenuItem[] outSpecificItems) {
+        int result;
+        if (outSpecificItems != null) {
+            android.view.MenuItem[] nativeOutItems = new android.view.MenuItem[outSpecificItems.length];
+            result = mNativeMenu.addIntentOptions(groupId, itemId, order, caller, specifics, intent, flags, nativeOutItems);
+            for (int i = 0, length = outSpecificItems.length; i < length; i++) {
+                outSpecificItems[i] = new MenuItemWrapper(nativeOutItems[i]);
+            }
+        } else {
+            result = mNativeMenu.addIntentOptions(groupId, itemId, order, caller, specifics, intent, flags, null);
+        }
+        return result;
+    }
+
+    @Override
+    public void removeItem(int id) {
+        mNativeMap.remove(mNativeMenu.findItem(id));
+        mNativeMenu.removeItem(id);
+    }
+
+    @Override
+    public void removeGroup(int groupId) {
+        for (int i = 0; i < mNativeMenu.size(); i++) {
+          final android.view.MenuItem item = mNativeMenu.getItem(i);
+          if (item.getGroupId() == groupId) { mNativeMap.remove(item); }
+        }
+        mNativeMenu.removeGroup(groupId);
+    }
+
+    @Override
+    public void clear() {
+        mNativeMap.clear();
+        mNativeMenu.clear();
+    }
+
+    public void invalidate() {
+        if (mNativeMap.isEmpty()) { return; }
+
+        final WeakHashMap<android.view.MenuItem, MenuItem> menuMapCopy = new WeakHashMap<android.view.MenuItem, MenuItem>(mNativeMap.size());
+
+        for (int i = 0; i < mNativeMenu.size(); i++) {
+          final android.view.MenuItem item = mNativeMenu.getItem(i);
+          menuMapCopy.put(item, mNativeMap.get(item));
+        }
+
+        mNativeMap.clear();
+        mNativeMap.putAll(menuMapCopy);
+    }
+
+    @Override
+    public void setGroupCheckable(int group, boolean checkable, boolean exclusive) {
+        mNativeMenu.setGroupCheckable(group, checkable, exclusive);
+    }
+
+    @Override
+    public void setGroupVisible(int group, boolean visible) {
+        mNativeMenu.setGroupVisible(group, visible);
+    }
+
+    @Override
+    public void setGroupEnabled(int group, boolean enabled) {
+        mNativeMenu.setGroupEnabled(group, enabled);
+    }
+
+    @Override
+    public boolean hasVisibleItems() {
+        return mNativeMenu.hasVisibleItems();
+    }
+
+    @Override
+    public MenuItem findItem(int id) {
+        android.view.MenuItem nativeItem = mNativeMenu.findItem(id);
+        return findItem(nativeItem);
+    }
+
+    public MenuItem findItem(android.view.MenuItem nativeItem) {
+        if (nativeItem == null) {
+            return null;
+        }
+
+        MenuItem wrapped = mNativeMap.get(nativeItem);
+        if (wrapped != null) {
+            return wrapped;
+        }
+
+        return addInternal(nativeItem);
+    }
+
+    @Override
+    public int size() {
+        return mNativeMenu.size();
+    }
+
+    @Override
+    public MenuItem getItem(int index) {
+        android.view.MenuItem nativeItem = mNativeMenu.getItem(index);
+        return findItem(nativeItem);
+    }
+
+    @Override
+    public void close() {
+        mNativeMenu.close();
+    }
+
+    @Override
+    public boolean performShortcut(int keyCode, KeyEvent event, int flags) {
+        return mNativeMenu.performShortcut(keyCode, event, flags);
+    }
+
+    @Override
+    public boolean isShortcutKey(int keyCode, KeyEvent event) {
+        return mNativeMenu.isShortcutKey(keyCode, event);
+    }
+
+    @Override
+    public boolean performIdentifierAction(int id, int flags) {
+        return mNativeMenu.performIdentifierAction(id, flags);
+    }
+
+    @Override
+    public void setQwertyMode(boolean isQwerty) {
+        mNativeMenu.setQwertyMode(isQwerty);
+    }
+}

--- a/src/test/java/fr/inria/coming/spoon/core/MainComingTest.java
+++ b/src/test/java/fr/inria/coming/spoon/core/MainComingTest.java
@@ -112,13 +112,8 @@ public class MainComingTest {
 
 		assertFalse(output.exists());
 
-		FinalResult result =
-				TestUtills.runRepairabilityWithParameters
-						(
-								"ALL",
-								"/pairsICSE15/",
-								"include_all_instances_for_each_tool:true"
-						);
+		FinalResult r = new ComingMain().run(
+				new String[] { "-mode", "features", "-location", "repogit4testv0"});
 
 		// the JSON file has been created
 		assertTrue(output.exists());

--- a/src/test/java/fr/inria/coming/spoon/core/MainComingTest.java
+++ b/src/test/java/fr/inria/coming/spoon/core/MainComingTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.github.difflib.text.DiffRow;
+import fr.inria.coming.spoon.repairability.TestUtills;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -103,16 +104,21 @@ public class MainComingTest {
 	}
 
 	@Test
-	public void testFeaturesMain() {
+	public void testFeaturesMain() throws Exception {
 		File output = new File("./coming_results/features_fe76517014e580ddcb40ac04ea824d54ba741c8b.json");
 
 		// clean test data
 		output.delete();
 
 		assertFalse(output.exists());
-		// the features mode does not crash
-		FinalResult r = new ComingMain().run(
-				new String[] { "-mode", "features", "-location", "repogit4testv0"});
+
+		FinalResult result =
+				TestUtills.runRepairabilityWithParameters
+						(
+								"ALL",
+								"/pairsICSE15/",
+								"include_all_instances_for_each_tool:true"
+						);
 
 		// the JSON file has been created
 		assertTrue(output.exists());

--- a/src/test/java/fr/inria/coming/spoon/repairability/RepairabilityTest.java
+++ b/src/test/java/fr/inria/coming/spoon/repairability/RepairabilityTest.java
@@ -7,10 +7,15 @@ import fr.inria.coming.changeminer.analyzer.instancedetector.PatternInstancesFro
 import fr.inria.coming.changeminer.entity.FinalResult;
 import fr.inria.coming.changeminer.entity.IRevision;
 import fr.inria.coming.core.entities.RevisionResult;
+import fr.inria.coming.main.ComingMain;
 import fr.inria.coming.repairability.RepairabilityAnalyzer;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileReader;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +37,7 @@ public class RepairabilityTest {
 
     @Test
     public void testDiffResults() throws Exception {
-        int count=0;
+        int count = 0;
         FinalResult result = TestUtills.runRepairabilityGit("ALL", "repogit4testv0");
         Map<IRevision, RevisionResult> revisionsMap = result.getAllResults();
         assertEquals(13, revisionsMap.keySet().size());
@@ -44,15 +49,15 @@ public class RepairabilityTest {
             List<DiffRow> row_list = instances.getRow_list();
 //            System.out.println("..........");
 //            System.out.println(row_list);
-            switch (count){
-                    case 1:
-                        assertEquals(row_list,null);
+            switch (count) {
+                case 1:
+                    assertEquals(row_list, null);
 
-                    case 9:
-                        assertEquals(row_list,null);
+                case 9:
+                    assertEquals(row_list, null);
 
-                    case 2:
-                    assertEquals(row_list,"[[INSERT,,/*], [INSERT,, * Licensed to the Apache Software Foundation (ASF) under one or more], [INSERT,, * contributor license agreements.  See the NOTICE file distributed with], [INSERT,, * this work for additional information regarding copyright ownership.], [INSERT,, * The ASF licenses this file to You under the Apache License, Version 2.0], [INSERT,, * (the \"License\"); you may not use this file except in compliance with], [INSERT,, * the License.  You may obtain a copy of the License at], [INSERT,, *], [INSERT,, *      http://www.apache.org/licenses/LICENSE-2.0], [INSERT,, *], [INSERT,, * Unless required by applicable law or agreed to in writing, software], [INSERT,, * distributed under the License is distributed on an \"AS IS\" BASIS,], [INSERT,, * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.], [INSERT,, * See the License for the specific language governing permissions and], [INSERT,, * limitations under the License.], [INSERT,, */], [INSERT,,package org.apache.commons.lang3;], [EQUAL,,], [INSERT,,/**], [INSERT,, * &lt;p&gt;Operations on {@link CharSequence} that are], [INSERT,, * {@code null} safe.&lt;/p&gt;], [INSERT,, *], [INSERT,, * @see CharSequence], [INSERT,, * @since 3.0], [INSERT,, * @version $Id$], [INSERT,, */], [INSERT,,public class CharSequenceUtils {], [INSERT,,], [INSERT,,    private static final int NOT_FOUND = -1;], [INSERT,,], [INSERT,,    /**], [INSERT,,     * &lt;p&gt;{@code CharSequenceUtils} instances should NOT be constructed in], [INSERT,,     * standard programming. &lt;/p&gt;], [INSERT,,     *], [INSERT,,     * &lt;p&gt;This constructor is public to permit tools that require a JavaBean], [INSERT,,     * instance to operate.&lt;/p&gt;], [INSERT,,     */], [INSERT,,    public CharSequenceUtils() {], [INSERT,,        super();], [INSERT,,    }], [INSERT,,], [INSERT,,    //-----------------------------------------------------------------------], [INSERT,,    /**], [INSERT,,     * &lt;p&gt;Returns a new {@code CharSequence} that is a subsequence of this], [INSERT,,     * sequence starting with the {@code char} value at the specified index.&lt;/p&gt;], [INSERT,,     *], [INSERT,,     * &lt;p&gt;This provides the {@code CharSequence} equivalent to {@link String#substring(int)}.], [INSERT,,     * The length (in {@code char}) of the returned sequence is {@code length() - start},], [INSERT,,     * so if {@code start == end} then an empty sequence is returned.&lt;/p&gt;], [INSERT,,     *], [INSERT,,     * @param cs  the specified subsequence, null returns null], [INSERT,,     * @param start  the start index, inclusive, valid], [INSERT,,     * @return a new subsequence, may be null], [INSERT,,     * @throws IndexOutOfBoundsException if {@code start} is negative or if ], [INSERT,,     *  {@code start} is greater than {@code length()}], [INSERT,,     */], [INSERT,,    public static CharSequence subSequence(final CharSequence cs, final int start) {], [INSERT,,        return cs == null ? null : cs.subSequence(start, cs.length());], [INSERT,,    }], [INSERT,,], [INSERT,,    //-----------------------------------------------------------------------], [INSERT,,    /**], [INSERT,,     * &lt;p&gt;Finds the first index in the {@code CharSequence} that matches the], [INSERT,,     * specified character.&lt;/p&gt;], [INSERT,,     *], [INSERT,,     * @param cs  the {@code CharSequence} to be processed, not null], [INSERT,,     * @param searchChar  the char to be searched for], [INSERT,,     * @param start  the start index, negative starts at the string start], [INSERT,,     * @return the index where the search char was found, -1 if not found], [INSERT,,     */], [INSERT,,    static int indexOf(final CharSequence cs, final int searchChar, int start) {], [INSERT,,        if (cs instanceof String) {], [INSERT,,            return ((String) cs).indexOf(searchChar, start);], [INSERT,,        }], [INSERT,,        final int sz = cs.length();], [INSERT,,        if (start &lt; 0) {], [INSERT,,            start = 0;], [INSERT,,        }], [INSERT,,        for (int i = start; i &lt; sz; i++) {], [INSERT,,            if (cs.charAt(i) == searchChar) {], [INSERT,,                return i;], [INSERT,,            }], [INSERT,,        }], [INSERT,,        return NOT_FOUND;], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * Used by the indexOf(CharSequence methods) as a green implementation of indexOf.], [INSERT,,     *], [INSERT,,     * @param cs the {@code CharSequence} to be processed], [INSERT,,     * @param searchChar the {@code CharSequence} to be searched for], [INSERT,,     * @param start the start index], [INSERT,,     * @return the index where the search sequence was found], [INSERT,,     */], [INSERT,,    static int indexOf(final CharSequence cs, final CharSequence searchChar, final int start) {], [INSERT,,        return cs.toString().indexOf(searchChar.toString(), start);], [INSERT,,//        if (cs instanceof String && searchChar instanceof String) {], [INSERT,,//            // TODO: Do we assume searchChar is usually relatively small;], [INSERT,,//            //       If so then calling toString() on it is better than reverting to], [INSERT,,//            //       the green implementation in the else block], [INSERT,,//            return ((String) cs).indexOf((String) searchChar, start);], [INSERT,,//        } else {], [INSERT,,//            // TODO: Implement rather than convert to String], [INSERT,,//            return cs.toString().indexOf(searchChar.toString(), start);], [INSERT,,//        }], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * &lt;p&gt;Finds the last index in the {@code CharSequence} that matches the], [INSERT,,     * specified character.&lt;/p&gt;], [INSERT,,     *], [INSERT,,     * @param cs  the {@code CharSequence} to be processed], [INSERT,,     * @param searchChar  the char to be searched for], [INSERT,,     * @param start  the start index, negative returns -1, beyond length starts at end], [INSERT,,     * @return the index where the search char was found, -1 if not found], [INSERT,,     */], [INSERT,,    static int lastIndexOf(final CharSequence cs, final int searchChar, int start) {], [INSERT,,        if (cs instanceof String) {], [INSERT,,            return ((String) cs).lastIndexOf(searchChar, start);], [INSERT,,        }], [INSERT,,        final int sz = cs.length();], [INSERT,,        if (start &lt; 0) {], [INSERT,,            return NOT_FOUND;], [INSERT,,        }], [INSERT,,        if (start &gt;= sz) {], [INSERT,,            start = sz - 1;], [INSERT,,        }], [INSERT,,        for (int i = start; i &gt;= 0; --i) {], [INSERT,,            if (cs.charAt(i) == searchChar) {], [INSERT,,                return i;], [INSERT,,            }], [INSERT,,        }], [INSERT,,        return NOT_FOUND;], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * Used by the lastIndexOf(CharSequence methods) as a green implementation of lastIndexOf], [INSERT,,     *], [INSERT,,     * @param cs the {@code CharSequence} to be processed], [INSERT,,     * @param searchChar the {@code CharSequence} to be searched for], [INSERT,,     * @param start the start index], [INSERT,,     * @return the index where the search sequence was found], [INSERT,,     */], [INSERT,,    static int lastIndexOf(final CharSequence cs, final CharSequence searchChar, final int start) {], [INSERT,,        return cs.toString().lastIndexOf(searchChar.toString(), start);], [INSERT,,//        if (cs instanceof String && searchChar instanceof String) {], [INSERT,,//            // TODO: Do we assume searchChar is usually relatively small;], [INSERT,,//            //       If so then calling toString() on it is better than reverting to], [INSERT,,//            //       the green implementation in the else block], [INSERT,,//            return ((String) cs).lastIndexOf((String) searchChar, start);], [INSERT,,//        } else {], [INSERT,,//            // TODO: Implement rather than convert to String], [INSERT,,//            return cs.toString().lastIndexOf(searchChar.toString(), start);], [INSERT,,//        }], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * Green implementation of toCharArray.], [INSERT,,     *], [INSERT,,     * @param cs the {@code CharSequence} to be processed], [INSERT,,     * @return the resulting char array], [INSERT,,     */], [INSERT,,    static char[] toCharArray(final CharSequence cs) {], [INSERT,,        if (cs instanceof String) {], [INSERT,,            return ((String) cs).toCharArray();], [INSERT,,        }], [INSERT,,        final int sz = cs.length();], [INSERT,,        final char[] array = new char[cs.length()];], [INSERT,,        for (int i = 0; i &lt; sz; i++) {], [INSERT,,            array[i] = cs.charAt(i);], [INSERT,,        }], [INSERT,,        return array;], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * Green implementation of regionMatches.], [INSERT,,     *], [INSERT,,     * @param cs the {@code CharSequence} to be processed], [INSERT,,     * @param ignoreCase whether or not to be case insensitive], [INSERT,,     * @param thisStart the index to start on the {@code cs} CharSequence], [INSERT,,     * @param substring the {@code CharSequence} to be looked for], [INSERT,,     * @param start the index to start on the {@code substring} CharSequence], [INSERT,,     * @param length character length of the region], [INSERT,,     * @return whether the region matched], [INSERT,,     */], [INSERT,,    static boolean regionMatches(final CharSequence cs, final boolean ignoreCase, final int thisStart,], [INSERT,,            final CharSequence substring, final int start, final int length)    {], [INSERT,,        if (cs instanceof String && substring instanceof String) {], [INSERT,,            return ((String) cs).regionMatches(ignoreCase, thisStart, (String) substring, start, length);], [INSERT,,        }], [INSERT,,        int index1 = thisStart;], [INSERT,,        int index2 = start;], [INSERT,,        int tmpLen = length;], [INSERT,,], [INSERT,,        while (tmpLen-- &gt; 0) {], [INSERT,,            final char c1 = cs.charAt(index1++);], [INSERT,,            final char c2 = substring.charAt(index2++);], [INSERT,,], [INSERT,,            if (c1 == c2) {], [INSERT,,                continue;], [INSERT,,            }], [INSERT,,], [INSERT,,            if (!ignoreCase) {], [INSERT,,                return false;], [INSERT,,            }], [INSERT,,], [INSERT,,            // The same check as in String.regionMatches():], [INSERT,,            if (Character.toUpperCase(c1) != Character.toUpperCase(c2)], [INSERT,,                    && Character.toLowerCase(c1) != Character.toLowerCase(c2)) {], [INSERT,,                return false;], [INSERT,,            }], [INSERT,,        }], [INSERT,,], [INSERT,,        return true;], [INSERT,,    }], [INSERT,,}]]\n");
+                case 2:
+                    assertEquals(row_list, "[[INSERT,,/*], [INSERT,, * Licensed to the Apache Software Foundation (ASF) under one or more], [INSERT,, * contributor license agreements.  See the NOTICE file distributed with], [INSERT,, * this work for additional information regarding copyright ownership.], [INSERT,, * The ASF licenses this file to You under the Apache License, Version 2.0], [INSERT,, * (the \"License\"); you may not use this file except in compliance with], [INSERT,, * the License.  You may obtain a copy of the License at], [INSERT,, *], [INSERT,, *      http://www.apache.org/licenses/LICENSE-2.0], [INSERT,, *], [INSERT,, * Unless required by applicable law or agreed to in writing, software], [INSERT,, * distributed under the License is distributed on an \"AS IS\" BASIS,], [INSERT,, * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.], [INSERT,, * See the License for the specific language governing permissions and], [INSERT,, * limitations under the License.], [INSERT,, */], [INSERT,,package org.apache.commons.lang3;], [EQUAL,,], [INSERT,,/**], [INSERT,, * &lt;p&gt;Operations on {@link CharSequence} that are], [INSERT,, * {@code null} safe.&lt;/p&gt;], [INSERT,, *], [INSERT,, * @see CharSequence], [INSERT,, * @since 3.0], [INSERT,, * @version $Id$], [INSERT,, */], [INSERT,,public class CharSequenceUtils {], [INSERT,,], [INSERT,,    private static final int NOT_FOUND = -1;], [INSERT,,], [INSERT,,    /**], [INSERT,,     * &lt;p&gt;{@code CharSequenceUtils} instances should NOT be constructed in], [INSERT,,     * standard programming. &lt;/p&gt;], [INSERT,,     *], [INSERT,,     * &lt;p&gt;This constructor is public to permit tools that require a JavaBean], [INSERT,,     * instance to operate.&lt;/p&gt;], [INSERT,,     */], [INSERT,,    public CharSequenceUtils() {], [INSERT,,        super();], [INSERT,,    }], [INSERT,,], [INSERT,,    //-----------------------------------------------------------------------], [INSERT,,    /**], [INSERT,,     * &lt;p&gt;Returns a new {@code CharSequence} that is a subsequence of this], [INSERT,,     * sequence starting with the {@code char} value at the specified index.&lt;/p&gt;], [INSERT,,     *], [INSERT,,     * &lt;p&gt;This provides the {@code CharSequence} equivalent to {@link String#substring(int)}.], [INSERT,,     * The length (in {@code char}) of the returned sequence is {@code length() - start},], [INSERT,,     * so if {@code start == end} then an empty sequence is returned.&lt;/p&gt;], [INSERT,,     *], [INSERT,,     * @param cs  the specified subsequence, null returns null], [INSERT,,     * @param start  the start index, inclusive, valid], [INSERT,,     * @return a new subsequence, may be null], [INSERT,,     * @throws IndexOutOfBoundsException if {@code start} is negative or if ], [INSERT,,     *  {@code start} is greater than {@code length()}], [INSERT,,     */], [INSERT,,    public static CharSequence subSequence(final CharSequence cs, final int start) {], [INSERT,,        return cs == null ? null : cs.subSequence(start, cs.length());], [INSERT,,    }], [INSERT,,], [INSERT,,    //-----------------------------------------------------------------------], [INSERT,,    /**], [INSERT,,     * &lt;p&gt;Finds the first index in the {@code CharSequence} that matches the], [INSERT,,     * specified character.&lt;/p&gt;], [INSERT,,     *], [INSERT,,     * @param cs  the {@code CharSequence} to be processed, not null], [INSERT,,     * @param searchChar  the char to be searched for], [INSERT,,     * @param start  the start index, negative starts at the string start], [INSERT,,     * @return the index where the search char was found, -1 if not found], [INSERT,,     */], [INSERT,,    static int indexOf(final CharSequence cs, final int searchChar, int start) {], [INSERT,,        if (cs instanceof String) {], [INSERT,,            return ((String) cs).indexOf(searchChar, start);], [INSERT,,        }], [INSERT,,        final int sz = cs.length();], [INSERT,,        if (start &lt; 0) {], [INSERT,,            start = 0;], [INSERT,,        }], [INSERT,,        for (int i = start; i &lt; sz; i++) {], [INSERT,,            if (cs.charAt(i) == searchChar) {], [INSERT,,                return i;], [INSERT,,            }], [INSERT,,        }], [INSERT,,        return NOT_FOUND;], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * Used by the indexOf(CharSequence methods) as a green implementation of indexOf.], [INSERT,,     *], [INSERT,,     * @param cs the {@code CharSequence} to be processed], [INSERT,,     * @param searchChar the {@code CharSequence} to be searched for], [INSERT,,     * @param start the start index], [INSERT,,     * @return the index where the search sequence was found], [INSERT,,     */], [INSERT,,    static int indexOf(final CharSequence cs, final CharSequence searchChar, final int start) {], [INSERT,,        return cs.toString().indexOf(searchChar.toString(), start);], [INSERT,,//        if (cs instanceof String && searchChar instanceof String) {], [INSERT,,//            // TODO: Do we assume searchChar is usually relatively small;], [INSERT,,//            //       If so then calling toString() on it is better than reverting to], [INSERT,,//            //       the green implementation in the else block], [INSERT,,//            return ((String) cs).indexOf((String) searchChar, start);], [INSERT,,//        } else {], [INSERT,,//            // TODO: Implement rather than convert to String], [INSERT,,//            return cs.toString().indexOf(searchChar.toString(), start);], [INSERT,,//        }], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * &lt;p&gt;Finds the last index in the {@code CharSequence} that matches the], [INSERT,,     * specified character.&lt;/p&gt;], [INSERT,,     *], [INSERT,,     * @param cs  the {@code CharSequence} to be processed], [INSERT,,     * @param searchChar  the char to be searched for], [INSERT,,     * @param start  the start index, negative returns -1, beyond length starts at end], [INSERT,,     * @return the index where the search char was found, -1 if not found], [INSERT,,     */], [INSERT,,    static int lastIndexOf(final CharSequence cs, final int searchChar, int start) {], [INSERT,,        if (cs instanceof String) {], [INSERT,,            return ((String) cs).lastIndexOf(searchChar, start);], [INSERT,,        }], [INSERT,,        final int sz = cs.length();], [INSERT,,        if (start &lt; 0) {], [INSERT,,            return NOT_FOUND;], [INSERT,,        }], [INSERT,,        if (start &gt;= sz) {], [INSERT,,            start = sz - 1;], [INSERT,,        }], [INSERT,,        for (int i = start; i &gt;= 0; --i) {], [INSERT,,            if (cs.charAt(i) == searchChar) {], [INSERT,,                return i;], [INSERT,,            }], [INSERT,,        }], [INSERT,,        return NOT_FOUND;], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * Used by the lastIndexOf(CharSequence methods) as a green implementation of lastIndexOf], [INSERT,,     *], [INSERT,,     * @param cs the {@code CharSequence} to be processed], [INSERT,,     * @param searchChar the {@code CharSequence} to be searched for], [INSERT,,     * @param start the start index], [INSERT,,     * @return the index where the search sequence was found], [INSERT,,     */], [INSERT,,    static int lastIndexOf(final CharSequence cs, final CharSequence searchChar, final int start) {], [INSERT,,        return cs.toString().lastIndexOf(searchChar.toString(), start);], [INSERT,,//        if (cs instanceof String && searchChar instanceof String) {], [INSERT,,//            // TODO: Do we assume searchChar is usually relatively small;], [INSERT,,//            //       If so then calling toString() on it is better than reverting to], [INSERT,,//            //       the green implementation in the else block], [INSERT,,//            return ((String) cs).lastIndexOf((String) searchChar, start);], [INSERT,,//        } else {], [INSERT,,//            // TODO: Implement rather than convert to String], [INSERT,,//            return cs.toString().lastIndexOf(searchChar.toString(), start);], [INSERT,,//        }], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * Green implementation of toCharArray.], [INSERT,,     *], [INSERT,,     * @param cs the {@code CharSequence} to be processed], [INSERT,,     * @return the resulting char array], [INSERT,,     */], [INSERT,,    static char[] toCharArray(final CharSequence cs) {], [INSERT,,        if (cs instanceof String) {], [INSERT,,            return ((String) cs).toCharArray();], [INSERT,,        }], [INSERT,,        final int sz = cs.length();], [INSERT,,        final char[] array = new char[cs.length()];], [INSERT,,        for (int i = 0; i &lt; sz; i++) {], [INSERT,,            array[i] = cs.charAt(i);], [INSERT,,        }], [INSERT,,        return array;], [INSERT,,    }], [INSERT,,], [INSERT,,    /**], [INSERT,,     * Green implementation of regionMatches.], [INSERT,,     *], [INSERT,,     * @param cs the {@code CharSequence} to be processed], [INSERT,,     * @param ignoreCase whether or not to be case insensitive], [INSERT,,     * @param thisStart the index to start on the {@code cs} CharSequence], [INSERT,,     * @param substring the {@code CharSequence} to be looked for], [INSERT,,     * @param start the index to start on the {@code substring} CharSequence], [INSERT,,     * @param length character length of the region], [INSERT,,     * @return whether the region matched], [INSERT,,     */], [INSERT,,    static boolean regionMatches(final CharSequence cs, final boolean ignoreCase, final int thisStart,], [INSERT,,            final CharSequence substring, final int start, final int length)    {], [INSERT,,        if (cs instanceof String && substring instanceof String) {], [INSERT,,            return ((String) cs).regionMatches(ignoreCase, thisStart, (String) substring, start, length);], [INSERT,,        }], [INSERT,,        int index1 = thisStart;], [INSERT,,        int index2 = start;], [INSERT,,        int tmpLen = length;], [INSERT,,], [INSERT,,        while (tmpLen-- &gt; 0) {], [INSERT,,            final char c1 = cs.charAt(index1++);], [INSERT,,            final char c2 = substring.charAt(index2++);], [INSERT,,], [INSERT,,            if (c1 == c2) {], [INSERT,,                continue;], [INSERT,,            }], [INSERT,,], [INSERT,,            if (!ignoreCase) {], [INSERT,,                return false;], [INSERT,,            }], [INSERT,,], [INSERT,,            // The same check as in String.regionMatches():], [INSERT,,            if (Character.toUpperCase(c1) != Character.toUpperCase(c2)], [INSERT,,                    && Character.toLowerCase(c1) != Character.toLowerCase(c2)) {], [INSERT,,                return false;], [INSERT,,            }], [INSERT,,        }], [INSERT,,], [INSERT,,        return true;], [INSERT,,    }], [INSERT,,}]]\n");
 
 
             }
@@ -85,4 +90,114 @@ public class RepairabilityTest {
         }
     }
 
+    @Test
+    public void testExcludeNotFullyCoveringInstances() throws Exception {
+        FinalResult result =
+                TestUtills.runRepairabilityWithParameters
+                        (
+                                "ALL",
+                                "/repairability_test_files/exclude_not_covering/",
+                                "exclude_repair_patterns_not_covering_the_whole_diff:true"
+                        );
+
+        Map<IRevision, RevisionResult> revisionsMap = result.getAllResults();
+        assertEquals(2, revisionsMap.keySet().size());
+
+        for (Map.Entry<IRevision, RevisionResult> entry : revisionsMap.entrySet()) {
+            RevisionResult rr = entry.getValue();
+            PatternInstancesFromRevision instances =
+                    (PatternInstancesFromRevision) rr.getResultFromClass(RepairabilityAnalyzer.class);
+
+            // for each revision
+            for (PatternInstancesFromDiff v : instances.getInfoPerDiff()) {
+                if(v.getLocation().equals("covered")) // for the covered sample
+                    assertTrue(v.getInstances().size() > 0);
+                else if(v.getLocation().equals("not_covered")) // for the not covered sample
+                    assertTrue(v.getInstances().size() == 0);
+            }
+        }
+    }
+
+    @Test
+    public void testCheckIncludeAllInstancesParameter() throws Exception {
+        FinalResult result =
+                TestUtills.runRepairabilityWithParameters
+                        (
+                                "ALL",
+                                "/pairsICSE15/", // has repetitive tool use for single revision
+                                "include_all_instances_for_each_tool:true"
+                        );
+        boolean hasRepetitiveToolUseForSingleRevision = checkIncludingRepetitiveToolUseForSingleRevision(result);
+        assertTrue(hasRepetitiveToolUseForSingleRevision);
+
+        result =
+                TestUtills.runRepairabilityWithParameters
+                        (
+                                "ALL",
+                                "/pairsICSE15/",
+                                "include_all_instances_for_each_tool:false"
+                        );
+        hasRepetitiveToolUseForSingleRevision = checkIncludingRepetitiveToolUseForSingleRevision(result);
+        assertFalse(hasRepetitiveToolUseForSingleRevision);
+
+        result =
+                TestUtills.runRepairability
+                        (
+                                "ALL",
+                                "/pairsICSE15/"
+                        );
+        hasRepetitiveToolUseForSingleRevision = checkIncludingRepetitiveToolUseForSingleRevision(result);
+        assertFalse(hasRepetitiveToolUseForSingleRevision);
+    }
+
+    @Test
+    public void testJSONRepairabilityOutputPrintModeParameter() throws Exception {
+        File output = new File("./coming_results/all_instances_found.json");
+        // clean test data
+        output.delete();
+        assertFalse(output.exists());
+
+        FinalResult r = TestUtills.runRepairabilityWithParameters
+                (
+                        "ALL",
+                        "/repairability_test_files/exclude_not_covering/",
+                        "exclude_repair_patterns_not_covering_the_whole_diff:true:print_only_repair_results:true"
+                );
+
+        // the JSON file has been created
+        assertTrue(output.exists());
+
+        JSONParser parser = new JSONParser();
+        JSONObject jo = (JSONObject) parser.parse(new FileReader(output));
+        JSONArray ja = (JSONArray) jo.get("instances");
+        // if it was PatternInstanceAnalyzer output, it would also include some instances for not_covered
+        assertEquals(ja.size(), 1);
+    }
+
+
+
+    private boolean checkIncludingRepetitiveToolUseForSingleRevision(FinalResult result) {
+        Map<IRevision, RevisionResult> revisionsMap = result.getAllResults();
+        boolean hasRepetitiveToolUseForSingleRevision = false;
+        for (Map.Entry<IRevision, RevisionResult> entry : revisionsMap.entrySet()) {
+            RevisionResult rr = entry.getValue();
+            PatternInstancesFromRevision instances = (PatternInstancesFromRevision) rr.getResultFromClass(RepairabilityAnalyzer.class);
+
+            // for each revision
+            Set<String> toolsSeen = new HashSet<>();
+            for (PatternInstancesFromDiff v : instances.getInfoPerDiff()) {
+                for (ChangePatternInstance patternInstance : v.getInstances()) {
+                    String toolName = patternInstance.getPattern().getName().split(File.pathSeparator)[0];
+                    if (toolsSeen.contains(toolName)) {
+                        hasRepetitiveToolUseForSingleRevision = true;
+                        break;
+                    }
+                    toolsSeen.add(toolName);
+                }
+                if (hasRepetitiveToolUseForSingleRevision)
+                    break;
+            }
+        }
+        return hasRepetitiveToolUseForSingleRevision;
+    }
 }

--- a/src/test/java/fr/inria/coming/spoon/repairability/TestUtills.java
+++ b/src/test/java/fr/inria/coming/spoon/repairability/TestUtills.java
@@ -7,6 +7,7 @@ import fr.inria.coming.core.entities.RevisionResult;
 import fr.inria.coming.main.ComingMain;
 import fr.inria.coming.repairability.RepairabilityAnalyzer;
 
+import java.net.URLDecoder;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -39,7 +40,31 @@ public class TestUtills {
                         "-input",
                         "files",
                         "-location",
-                        TestUtills.class.getResource(inputFiles).getFile()});
+                        URLDecoder.decode(TestUtills.class.getResource(inputFiles).getFile(), "UTF-8")});
+
+        assertNotNull(result);
+        return result;
+    }
+
+    public static FinalResult runRepairabilityWithParameters
+            (
+                    String toolName,
+                    String inputFiles,
+                    String parameters // ex. "include_all_instances_for_each_tool:true:X:false:Y:true"
+            ) throws Exception {
+        ComingMain cm = new ComingMain();
+
+        FinalResult result = cm.run(
+                new String[]{"-mode",
+                        "repairability",
+                        "-repairtool",
+                        toolName,
+                        "-input",
+                        "files",
+                        "-parameters",
+                        parameters,
+                        "-location",
+                        URLDecoder.decode(TestUtills.class.getResource(inputFiles).getFile(), "UTF-8")});
 
         assertNotNull(result);
         return result;


### PR DESCRIPTION
Hi,

Three options are added.

1&2- "include_all_instances_for_each_tool" & "exclude_repair_patterns_not_covering_the_whole_diff" that can be set by "-parameter include_all_instances_for_each_tool:true". The first one causes the output to include all instances of each tool (not only one for each tool). The second one (if set true) excludes the instancePatterns that do not cover the whole diff. see: [link](https://github.com/khaes-kth/coming/blob/master/src/main/java/fr/inria/coming/repairability/RepairabilityAnalyzer.java#L69)

3- "print_only_repair_results" which can be set in the same way. If set true, repairability mode returns the results of RepairabilityAnalyzer not PatternInstanceAnalyzer. This one is a temporary fix for #172 
 see: [link](https://github.com/khaes-kth/coming/blob/master/src/main/java/fr/inria/coming/repairability/JSONRepairabilityOutput.java#L32)