### PR TITLE
[bugfix] NPE when analyzing elements that do not have associated a GT

### DIFF
--- a/src/main/java/fr/inria/coming/codefeatures/codeanalyze/AbstractCodeAnalyzer.java
+++ b/src/main/java/fr/inria/coming/codefeatures/codeanalyze/AbstractCodeAnalyzer.java
@@ -42,17 +42,16 @@ import spoon.reflect.visitor.filter.LineFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
 public abstract class AbstractCodeAnalyzer {
-	
+
 	protected CodeElementInfo elementinfo;
-	
+
 	AbstractCodeAnalyzer(CodeElementInfo inputinfo) {
 		this.elementinfo = inputinfo;
 	}
 
 	public abstract void analyze();
-	
-	public void writeGroupedInfo(Cntx<Object> context, String key, CodeFeatures property, Boolean value,
-			String type) {
+
+	public void writeGroupedInfo(Cntx<Object> context, String key, CodeFeatures property, Boolean value, String type) {
 
 		Cntx<Object> featuresVar = (Cntx<Object>) context.getInformation().get(type);
 		if (featuresVar == null) {
@@ -66,14 +65,18 @@ public abstract class AbstractCodeAnalyzer {
 		}
 		particularVar.getInformation().put(property.name(), value);
 	}
-	
-	public String adjustIdentifyInJson (CtElement spoonElement) { 
-			
-			ITree gumtreeObject=(ITree) spoonElement.getMetadata("gtnode");
-			
+
+	public String adjustIdentifyInJson(CtElement spoonElement) {
+
+		if (spoonElement.getAllMetadata().containsKey("gtnode")) {
+			ITree gumtreeObject = (ITree) spoonElement.getMetadata("gtnode");
+
 			return gumtreeObject.getLabel();
-    }
-	
+		} else {
+			return spoonElement.getShortRepresentation();
+		}
+	}
+
 	/**
 	 * If the faulty statement involves object reference to local variables (i.e.,
 	 * use object type local variables), do there exist certain referenced local
@@ -119,18 +122,18 @@ public abstract class AbstractCodeAnalyzer {
 			for (CtVariableAccess variableAffected : varsAffected) {
 
 				boolean varHasAssig = false;
-				
-                CtStatement parent = variableAffected.getParent(new LineFilter());
-				
-				if(isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
+
+				CtStatement parent = variableAffected.getParent(new LineFilter());
+
+				if (isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
 					continue;
 				// For each assignment in the method
 				for (CtAssignment assignment : assignments) {
-					
+
 					if (!isElementBeforeVariable(variableAffected, assignment))
 						continue;
-					
-					if (isStatementInControl(parent, assignment) || parent==assignment)
+
+					if (isStatementInControl(parent, assignment) || parent == assignment)
 						continue;
 
 					if (assignment.getAssigned().toString().equals(variableAffected.getVariable().getSimpleName())) {
@@ -168,20 +171,20 @@ public abstract class AbstractCodeAnalyzer {
 					else
 						nrOfLocalVarWithoutAssignment++;
 				}
-				
-				if(nrOfLocalVarWithoutAssignment > 0)
+
+				if (nrOfLocalVarWithoutAssignment > 0)
 					break;
 			}
-			
+
 			return nrOfLocalVarWithoutAssignment > 0;
-			
+
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Return if the element is a guard
 	 * 
@@ -206,16 +209,16 @@ public abstract class AbstractCodeAnalyzer {
 
 				CtIf guardCandidateIf = (CtIf) parentElement;
 
-			    if(whethereffectiveguard(guardCandidateIf, parentStatement)) {
-				    condition = guardCandidateIf.getCondition();
-				    boolean isConditionAGuard = checkNormalGuardCondition(condition);
-				    return isConditionAGuard;
-			    }
+				if (whethereffectiveguard(guardCandidateIf, parentStatement)) {
+					condition = guardCandidateIf.getCondition();
+					boolean isConditionAGuard = checkNormalGuardCondition(condition);
+					return isConditionAGuard;
+				}
 			}
 		}
 		return false;
 	}
-	
+
 	public boolean isNullCheckGuard(CtElement element, CtStatement parentStatement) {
 
 		// Two cases: if and conditional
@@ -235,16 +238,16 @@ public abstract class AbstractCodeAnalyzer {
 
 				CtIf guardCandidateIf = (CtIf) parentElement;
 
-			    if(whethereffectiveguard(guardCandidateIf, parentStatement)) {
-				    condition = guardCandidateIf.getCondition();
-				    boolean isConditionAGuard = checkNullCheckGuardCondition(condition);
-				    return isConditionAGuard;
-			    }
+				if (whethereffectiveguard(guardCandidateIf, parentStatement)) {
+					condition = guardCandidateIf.getCondition();
+					boolean isConditionAGuard = checkNullCheckGuardCondition(condition);
+					return isConditionAGuard;
+				}
 			}
 		}
 		return false;
 	}
-	
+
 	public boolean isElementBeforeVariable(CtVariableAccess variableAffected, CtElement element) {
 
 		try {
@@ -262,22 +265,23 @@ public abstract class AbstractCodeAnalyzer {
 		return false;
 
 	}
-	
+
 	public boolean isStatementInControl(CtStatement targetstatement, CtStatement statementtocompare) {
 		CtElement parentelement = targetstatement.getParent();
-		int layer=0;
+		int layer = 0;
 		CtElement parent;
-		parent=statementtocompare;
+		parent = statementtocompare;
 		do {
-			parent= parent.getParent();
+			parent = parent.getParent();
 			layer++;
-		} while (parent!=parentelement && parent!=null);
-		
-		if(layer>1 && parent!=null)
+		} while (parent != parentelement && parent != null);
+
+		if (layer > 1 && parent != null)
 			return true;
-		else return false;
+		else
+			return false;
 	}
-	
+
 	/**
 	 * Return if the Condition is a guard
 	 * 
@@ -299,11 +303,11 @@ public abstract class AbstractCodeAnalyzer {
 				}
 			}
 
-           return true;
+			return true;
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Returns a parent that is not a block
 	 * 
@@ -319,26 +323,26 @@ public abstract class AbstractCodeAnalyzer {
 
 		return aStatement.getParent();
 	}
-	
+
 	public static boolean whethereffectiveguard(CtIf ifstatement, CtStatement targetstatement) {
 		CtBlock thenBlock = ifstatement.getThenStatement();
 		CtBlock elseBlock = ifstatement.getElseStatement();
-		
-		if(thenBlock!=null) {
-			List<CtStatement> thenstatements=thenBlock.getStatements();
-			if(thenstatements.size()>0 && thenstatements.get(0)==targetstatement)
+
+		if (thenBlock != null) {
+			List<CtStatement> thenstatements = thenBlock.getStatements();
+			if (thenstatements.size() > 0 && thenstatements.get(0) == targetstatement)
 				return true;
 		}
-		
-		if(elseBlock!=null) {
-			List<CtStatement> elsestatements=elseBlock.getStatements();
-			if(elsestatements.size()>0 && elsestatements.get(0)==targetstatement)
+
+		if (elseBlock != null) {
+			List<CtStatement> elsestatements = elseBlock.getStatements();
+			if (elsestatements.size() > 0 && elsestatements.get(0) == targetstatement)
 				return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	public boolean checkNullCheckGuardCondition(CtExpression condition) {
 		if (condition != null) {
 			List<CtBinaryOperator> binOp = condition.getElements(new TypeFilter<>(CtBinaryOperator.class));
@@ -351,15 +355,15 @@ public abstract class AbstractCodeAnalyzer {
 						return false;
 					}
 				}
-				
+
 				return true;
 			}
 
-           return false;
+			return false;
 		}
 		return false;
 	}
-	
+
 	/**
 	 * If the faulty statement involves object reference to local variables (i.e.,
 	 * use object type local variables), do there exist certain referenced local
@@ -373,15 +377,15 @@ public abstract class AbstractCodeAnalyzer {
 	 */
 	@SuppressWarnings("rawtypes")
 	public boolean analyze_AffectedVariablesUsed(List<CtVariableAccess> varsAffected, CtElement element,
-			 List<CtStatement> statements) {
-		
+			List<CtStatement> statements) {
+
 		try {
 			CtExecutable methodParent = element.getParent(CtExecutable.class);
 
 			if (methodParent == null)
 				// the element is not in a method.
 				return false;
-			statements=methodParent.getElements(new LineFilter());
+			statements = methodParent.getElements(new LineFilter());
 
 			int usedObjects = 0;
 			int notUsedObjects = 0;
@@ -396,32 +400,31 @@ public abstract class AbstractCodeAnalyzer {
 
 				boolean aVarUsed = false;
 				// boolean foundSimilarVarUsedBefore = false;
-				
-                CtStatement parent = variableAffected.getParent(new LineFilter());
-				
-				if(isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
+
+				CtStatement parent = variableAffected.getParent(new LineFilter());
+
+				if (isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
 					continue;
 
 				// For each assignment in the methid
 				for (CtStatement aStatement : statements) {
-					
+
 					List<CtVariableAccess> varsInRightPart;
-					
+
 					if (!isElementBeforeVariable(variableAffected, aStatement))
 						continue;
-					
-					if (isStatementInControl(parent, aStatement) || parent==aStatement)
+
+					if (isStatementInControl(parent, aStatement) || parent == aStatement)
 						continue;
-					
-					if(aStatement instanceof CtIf || aStatement instanceof CtLoop) {
+
+					if (aStatement instanceof CtIf || aStatement instanceof CtLoop) {
 						varsInRightPart = VariableResolver.collectVariableRead(retrieveElementToStudy(aStatement));
-					} else 
+					} else
 						varsInRightPart = VariableResolver.collectVariableRead(aStatement);
-					
+
 					// if the var access in the right is the same that the affected
 					for (CtVariableAccess varInStatement : varsInRightPart) {
-						if (hasSameName(variableAffected, varInStatement)
-								) {
+						if (hasSameName(variableAffected, varInStatement)) {
 							aVarUsed = true;
 							break;
 						}
@@ -454,25 +457,25 @@ public abstract class AbstractCodeAnalyzer {
 								notUsedPrimitiveLocal++;
 					}
 				}
-				
-				if(notUsedObjectsLocal > 0)
+
+				if (notUsedObjectsLocal > 0)
 					break;
 			}
-			
+
 			return (notUsedObjectsLocal) > 0;
-			
+
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}
-		
+
 		return false;
-	}	
-	
+	}
+
 	public boolean hasSameName(CtVariableAccess variableAffected, CtVariableAccess varInStatement) {
 		return varInStatement.getVariable().getSimpleName().equals(variableAffected.getVariable().getSimpleName())
 				|| varInStatement.equals(variableAffected);
 	}
-	
+
 	public CtElement retrieveElementToStudy(CtElement element) {
 
 		if (element instanceof CtIf) {
@@ -490,7 +493,7 @@ public abstract class AbstractCodeAnalyzer {
 		} else
 			return (element);
 	}
-	
+
 	public boolean[] analyze_SametypewithGuard(List<CtVariableAccess> varsAffected, CtElement element,
 			CtClass parentClass, List<CtStatement> statements) {
 
@@ -510,23 +513,23 @@ public abstract class AbstractCodeAnalyzer {
 			for (CtVariableAccess variableAffected : varsAffected) {
 				// for (CtStatement aStatement : statements) {
 				CtStatement parent = variableAffected.getParent(new LineFilter());
-				
-				if(isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
+
+				if (isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
 					continue;
-				
+
 				// For each statement in the method (it includes the statements inside the
 				// blocks (then, while)!)
 				for (CtStatement aStatement : statements) {
 					// for (CtVariableAccess variableAffected : varsAffected) {
-					
-					if (parent==aStatement) 
+
+					if (parent == aStatement)
 						continue;
-					
+
 					List<CtVariableAccess> varsFromStatement;
-					
-					if(aStatement instanceof CtIf || aStatement instanceof CtLoop) {
+
+					if (aStatement instanceof CtIf || aStatement instanceof CtLoop) {
 						varsFromStatement = VariableResolver.collectVariableRead(retrieveElementToStudy(aStatement));
-					} else 
+					} else
 						varsFromStatement = VariableResolver.collectVariableRead(aStatement);
 //
 //					// let's collect the var access in the statement
@@ -537,29 +540,29 @@ public abstract class AbstractCodeAnalyzer {
 						// Has similar type but different name
 						if (compareTypes(variableAffected.getVariable().getType(),
 								varInStatement.getVariable().getType())) {
-							//	&& !hasSameName(variableAffected, varInStatement)) {
+							// && !hasSameName(variableAffected, varInStatement)) {
 							// Now, let's check if the parent is a guard
 							// if (isGuard(getParentNotBlock(aStatement))) {
 							if (isNormalGuard(varInStatement, (aStatement))) {
 
 								// it's ok, now let's check the type
 								if (variableAffected.getType() != null) {
-                                    // for primitive type variables, we require it to be the same global variable
-									if (variableAffected.getType().isPrimitive() && varInStatement.getVariable().getSimpleName().
-											equals(variableAffected.getVariable().getSimpleName()))
+									// for primitive type variables, we require it to be the same global variable
+									if (variableAffected.getType().isPrimitive() && varInStatement.getVariable()
+											.getSimpleName().equals(variableAffected.getVariable().getSimpleName()))
 										hasPrimitiveSimilarTypeWithNormalGuard = true;
 									else
 										hasObjectSimilarTypeWithNormalGuard = true;
 								}
 							}
-							
+
 							if (isNullCheckGuard(varInStatement, (aStatement))) {
 
 								// it's ok, now let's check the type
 								if (variableAffected.getType() != null) {
 
-									if (variableAffected.getType().isPrimitive() && varInStatement.getVariable().getSimpleName().
-											equals(variableAffected.getVariable().getSimpleName()))
+									if (variableAffected.getType().isPrimitive() && varInStatement.getVariable()
+											.getSimpleName().equals(variableAffected.getVariable().getSimpleName()))
 										hasPrimitiveSimilarTypeWithNullGuard = true;
 									else
 										hasObjectSimilarTypeWithNullGuard = true;
@@ -569,8 +572,8 @@ public abstract class AbstractCodeAnalyzer {
 						}
 					}
 					// If we find both cases, we can stop
-					if (hasPrimitiveSimilarTypeWithNormalGuard && hasObjectSimilarTypeWithNormalGuard &&
-							hasPrimitiveSimilarTypeWithNullGuard && hasObjectSimilarTypeWithNullGuard)
+					if (hasPrimitiveSimilarTypeWithNormalGuard && hasObjectSimilarTypeWithNormalGuard
+							&& hasPrimitiveSimilarTypeWithNullGuard && hasObjectSimilarTypeWithNullGuard)
 						break;
 				}
 			}
@@ -578,29 +581,30 @@ public abstract class AbstractCodeAnalyzer {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}
-		
+
 		boolean[] expressionvalue = new boolean[4];
-		expressionvalue[0]=hasObjectSimilarTypeWithNormalGuard;
-		expressionvalue[1]=hasPrimitiveSimilarTypeWithNormalGuard;
-		expressionvalue[2]=hasObjectSimilarTypeWithNullGuard;
-		expressionvalue[3]=hasPrimitiveSimilarTypeWithNullGuard;
-		
+		expressionvalue[0] = hasObjectSimilarTypeWithNormalGuard;
+		expressionvalue[1] = hasPrimitiveSimilarTypeWithNormalGuard;
+		expressionvalue[2] = hasObjectSimilarTypeWithNullGuard;
+		expressionvalue[3] = hasPrimitiveSimilarTypeWithNullGuard;
+
 		return expressionvalue;
 
 	}
-	
+
 	public static boolean compareTypes(CtTypeReference t1, CtTypeReference t2) {
 		try {
-			
-			return t1 != null && t2 != null && (t1.toString().equals(t2.toString()) || 
-					t1.toString().toLowerCase().endsWith(t2.toString().toLowerCase()) ||
-					t2.toString().toLowerCase().endsWith(t1.toString().toLowerCase()) ||
-					t1.equals(t2) || t1.isSubtypeOf(t2) || t2.isSubtypeOf(t1));
+
+			return t1 != null && t2 != null
+					&& (t1.toString().equals(t2.toString())
+							|| t1.toString().toLowerCase().endsWith(t2.toString().toLowerCase())
+							|| t2.toString().toLowerCase().endsWith(t1.toString().toLowerCase()) || t1.equals(t2)
+							|| t1.isSubtypeOf(t2) || t2.isSubtypeOf(t1));
 		} catch (Exception e) {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * // If the faulty statement involves object reference to field (i.e., use
 	 * object type class field), do there exist certain field(s) that have never
@@ -616,23 +620,23 @@ public abstract class AbstractCodeAnalyzer {
 			CtMethod methodParent = element.getParent(CtMethod.class);
 			if (parentClass == null || methodParent == null)
 				return false;
-			
+
 			List<CtStatement> statements = methodParent.getElements(new LineFilter());
 
 			boolean hasFieldNeverUsedOutside = false;
 			// For each variable affected in the faulty statement
 			for (CtVariableAccess variableAffected : varsAffected) {
-				
-                CtStatement parent = variableAffected.getParent(new LineFilter());
-				
-				if(isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
+
+				CtStatement parent = variableAffected.getParent(new LineFilter());
+
+				if (isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
 					continue;
-				
+
 				// if it's a field
 				if (variableAffected instanceof CtFieldAccess) {
-					
-					if(variableAffected.getVariable().getType() == null || 
-							variableAffected.getVariable().getType().isPrimitive())
+
+					if (variableAffected.getVariable().getType() == null
+							|| variableAffected.getVariable().getType().isPrimitive())
 						continue;
 
 					boolean isFieldUsed = false;
@@ -657,31 +661,30 @@ public abstract class AbstractCodeAnalyzer {
 							}
 						}
 
-						if(isFieldUsed)
+						if (isFieldUsed)
 							break;
 					}
-					
-                    boolean aVarUsedInFaultyMethod = false;
-					
+
+					boolean aVarUsedInFaultyMethod = false;
+
 					for (CtStatement aStatement : statements) {
-						
+
 						List<CtVariableAccess> varsInRightPart;
-						
+
 						if (!isElementBeforeVariable(variableAffected, aStatement))
 							continue;
-						
-						if (isStatementInControl(parent, aStatement) || parent==aStatement)
+
+						if (isStatementInControl(parent, aStatement) || parent == aStatement)
 							continue;
-						
-						if(aStatement instanceof CtIf || aStatement instanceof CtLoop) {
+
+						if (aStatement instanceof CtIf || aStatement instanceof CtLoop) {
 							varsInRightPart = VariableResolver.collectVariableRead(retrieveElementToStudy(aStatement));
-						} else 
+						} else
 							varsInRightPart = VariableResolver.collectVariableRead(aStatement);
-						
+
 						// if the var access in the right is the same that the affected
 						for (CtVariableAccess varInStatement : varsInRightPart) {
-							if (hasSameName(variableAffected, varInStatement)
-									) {
+							if (hasSameName(variableAffected, varInStatement)) {
 								aVarUsedInFaultyMethod = true;
 								break;
 							}
@@ -689,34 +692,36 @@ public abstract class AbstractCodeAnalyzer {
 						if (aVarUsedInFaultyMethod)
 							break;
 					}
-					// If the filed is never used on other methods and never used before the faulty statement in the faulty method
+					// If the filed is never used on other methods and never used before the faulty
+					// statement in the faulty method
 					if (!isFieldUsed && !aVarUsedInFaultyMethod)
 						hasFieldNeverUsedOutside = true;
-					
-					if(hasFieldNeverUsedOutside)
+
+					if (hasFieldNeverUsedOutside)
 						break;
 				}
 			}
-			
+
 			return hasFieldNeverUsedOutside;
-			
+
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}
-		
+
 		return false;
 	}
-	
-	public boolean analyze_AffectedFieldAssigned (List<CtVariableAccess> varsAffected, CtElement element, CtClass parentClass) {
-		
-		 try {
+
+	public boolean analyze_AffectedFieldAssigned(List<CtVariableAccess> varsAffected, CtElement element,
+			CtClass parentClass) {
+
+		try {
 			CtMethod methodParent = element.getParent(CtMethod.class);
-			
+
 			if (parentClass == null || methodParent == null)
 				return false;
-			
+
 			List<CtStatement> statements = methodParent.getElements(new LineFilter());
-			
+
 			List<CtAssignment> assignments = new ArrayList<>();
 			List<CtField> allfields = new ArrayList<>();
 
@@ -735,55 +740,57 @@ public abstract class AbstractCodeAnalyzer {
 					allfields.add(filed);
 				}
 			};
-			
+
 			assignmentScanner.scan(parentClass);
-			
+
 			boolean hasFieldNeverAssigned = false;
 			// For each variable affected in the faulty statement
 			for (CtVariableAccess variableAffected : varsAffected) {
-				
-                CtStatement parent = variableAffected.getParent(new LineFilter());
-				
-				if(isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
+
+				CtStatement parent = variableAffected.getParent(new LineFilter());
+
+				if (isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
 					continue;
-				
+
 				// if it's a field
 				if (variableAffected instanceof CtFieldAccess) {
-					
-					if(variableAffected.getVariable().getType() == null || 
-							variableAffected.getVariable().getType().isPrimitive())
+
+					if (variableAffected.getVariable().getType() == null
+							|| variableAffected.getVariable().getType().isPrimitive())
 						continue;
 
 					boolean isFieldAssigned = false;
-					
+
 					for (CtAssignment assignment : assignments) {
-						
-						CtMethod methodParentAssign = assignment.getParent(CtMethod.class); 
-												
-						if(methodParentAssign!=null && methodParentAssign.equals(methodParent)) {
-							
+
+						CtMethod methodParentAssign = assignment.getParent(CtMethod.class);
+
+						if (methodParentAssign != null && methodParentAssign.equals(methodParent)) {
+
 							if (!isElementBeforeVariable(variableAffected, assignment))
 								continue;
-							
-							if (isStatementInControl(parent, assignment) || parent==assignment)
+
+							if (isStatementInControl(parent, assignment) || parent == assignment)
 								continue;
 
-							if (assignment.getAssigned().toString().equals(variableAffected.getVariable().getSimpleName())) {
+							if (assignment.getAssigned().toString()
+									.equals(variableAffected.getVariable().getSimpleName())) {
 								isFieldAssigned = true;
 								break;
 							}
 						} else {
-							
-							if (assignment.getAssigned().toString().equals(variableAffected.getVariable().getSimpleName())) {
+
+							if (assignment.getAssigned().toString()
+									.equals(variableAffected.getVariable().getSimpleName())) {
 								isFieldAssigned = true;
 								break;
 							}
 						}
-						
-						if(isFieldAssigned)
+
+						if (isFieldAssigned)
 							break;
 					}
-					
+
 					if (!isFieldAssigned) {
 
 						for (CtField specificField : allfields) {
@@ -793,328 +800,332 @@ public abstract class AbstractCodeAnalyzer {
 									&& specificField.getDefaultExpression() != null
 									&& !"null".equals(specificField.getDefaultExpression().toString()))
 								isFieldAssigned = true;
-							    break;
+							break;
 						}
 					}
-					
-					// If the filed is never used on other methods and never used before the faulty statement in the faulty method
+
+					// If the filed is never used on other methods and never used before the faulty
+					// statement in the faulty method
 					if (!isFieldAssigned)
 						hasFieldNeverAssigned = true;
-					
-					if(hasFieldNeverAssigned)
+
+					if (hasFieldNeverAssigned)
 						break;
 				}
 			}
-			
+
 			return hasFieldNeverAssigned;
-		
+
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}
-		 
+
 		return false;
 	}
-	
-	 // S7: If the faulty statement involves object reference (either local or class field), 
- 	// do there exist certain referenced variable(s) for which the last time they appear in the faulty class 
- 	// (before the faulty statement and exclude statements in control structure) are left-hand side of assignment. 
- 	// S8: same, but primitive type variables
+
+	// S7: If the faulty statement involves object reference (either local or class
+	// field),
+	// do there exist certain referenced variable(s) for which the last time they
+	// appear in the faulty class
+	// (before the faulty statement and exclude statements in control structure) are
+	// left-hand side of assignment.
+	// S8: same, but primitive type variables
 	public boolean[] analyze_AffectedObjectLastAppear(List<CtVariableAccess> varsAffected, CtElement element,
- 			List<CtStatement> statements) {
- 		
- 		try {
- 			CtExecutable methodParent = element.getParent(CtExecutable.class);
+			List<CtStatement> statements) {
 
- 			if (methodParent == null)
- 				// the element is not in a method.
- 				return null;
- 			
- 			statements=methodParent.getElements(new LineFilter());
+		try {
+			CtExecutable methodParent = element.getParent(CtExecutable.class);
 
- 			int objectsLastAssign = 0;
- 			int objectsLastUse = 0;
- 			int primitiveLastAssign = 0;
- 			int primitiveLastUse = 0;
+			if (methodParent == null)
+				// the element is not in a method.
+				return null;
 
- 			// For each variable affected
- 			for (CtVariableAccess variableAffected : varsAffected) {
+			statements = methodParent.getElements(new LineFilter());
 
- 				boolean aVarAppearLastAssign = false;
- 				// boolean foundSimilarVarUsedBefore = false;
- 				
-                 CtStatement parent = variableAffected.getParent(new LineFilter());
- 				
- 				if(isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
- 					continue;
+			int objectsLastAssign = 0;
+			int objectsLastUse = 0;
+			int primitiveLastAssign = 0;
+			int primitiveLastUse = 0;
 
- 				// For each assignment in the methid
- 				for (CtStatement aStatement : statements) {
- 					
- 					List<CtVariableAccess> varsInRightPart;
- 					
- 					if (!isElementBeforeVariable(variableAffected, aStatement))
- 						continue;
- 					
- 					if (isStatementInControl(parent, aStatement) || parent==aStatement)
- 						continue;
- 					
- 					if(aStatement instanceof CtIf || aStatement instanceof CtLoop) {
- 						varsInRightPart = VariableResolver.collectVariableRead(retrieveElementToStudy(aStatement));
- 					} else 
- 						varsInRightPart = VariableResolver.collectVariableRead(aStatement);
- 					
- 					// if the var access in the right is the same that the affected
- 					for (CtVariableAccess varInStatement : varsInRightPart) {
- 						if (hasSameName(variableAffected, varInStatement)
- 								) {
- 							aVarAppearLastAssign = false;
- 						}
- 					}
- 					
- 					if(aStatement instanceof CtAssignment) {
- 						CtAssignment assignment=(CtAssignment)aStatement;
- 						if (assignment.getAssigned().toString().equals(variableAffected.getVariable().getSimpleName())) {
- 							aVarAppearLastAssign = true;
- 						}
- 					}
- 					
- 					if(aStatement instanceof CtLocalVariable) {
- 						CtLocalVariable ctLocalVariable=(CtLocalVariable)aStatement;
+			// For each variable affected
+			for (CtVariableAccess variableAffected : varsAffected) {
 
- 						if (ctLocalVariable.getReference().getSimpleName()
- 								.equals(variableAffected.getVariable().getSimpleName()))
- 							aVarAppearLastAssign = true;
- 					}
- 				}
- 				
- 				// Now, let's check the type of the var to see if it's local or not
- 				if (variableAffected.getVariable().getType() != null) {
+				boolean aVarAppearLastAssign = false;
+				// boolean foundSimilarVarUsedBefore = false;
 
- 					if (!variableAffected.getVariable().getType().isPrimitive()) {
- 						if (aVarAppearLastAssign)
- 							objectsLastAssign++;
- 						else
- 							objectsLastUse++;
+				CtStatement parent = variableAffected.getParent(new LineFilter());
 
- 					} else {
+				if (isNormalGuard(variableAffected, (parent)) || isNullCheckGuard(variableAffected, (parent)))
+					continue;
 
- 						if (variableAffected.getVariable().getType().isPrimitive())
- 							if (aVarAppearLastAssign)
- 								primitiveLastAssign++;
- 							else
- 								primitiveLastUse++;
- 					}
- 				}
- 				
- 				if(objectsLastAssign > 0 && primitiveLastAssign > 0)
- 					break;
- 			}
- 			
- 			boolean[] expressionfeatures= new boolean[2];
- 			
- 			expressionfeatures[0]=(objectsLastAssign > 0);
- 			expressionfeatures[1]=(primitiveLastAssign > 0);
+				// For each assignment in the methid
+				for (CtStatement aStatement : statements) {
 
- 			return expressionfeatures;
- 			
- 		} catch (Throwable e) {
- 			e.printStackTrace();
- 		}
- 		
-	    boolean[] expressionfeaturesdefault= new boolean[2];
-	    expressionfeaturesdefault[0]=false;
-	    expressionfeaturesdefault[1]=false;
+					List<CtVariableAccess> varsInRightPart;
 
- 		return expressionfeaturesdefault;
- 	}
- 	
-	public boolean[] analyze_SamerMethodWithGuardOrTrywrap (CtElement element, CtClass parentClass,
-			List<CtInvocation> allinvocationsFromClass, List<CtInvocation> invocationstostudy, 
-		List<CtConstructorCall> allconstructorcallsFromClass, List<CtConstructorCall> constructorcallstostudy) {
-		
+					if (!isElementBeforeVariable(variableAffected, aStatement))
+						continue;
+
+					if (isStatementInControl(parent, aStatement) || parent == aStatement)
+						continue;
+
+					if (aStatement instanceof CtIf || aStatement instanceof CtLoop) {
+						varsInRightPart = VariableResolver.collectVariableRead(retrieveElementToStudy(aStatement));
+					} else
+						varsInRightPart = VariableResolver.collectVariableRead(aStatement);
+
+					// if the var access in the right is the same that the affected
+					for (CtVariableAccess varInStatement : varsInRightPart) {
+						if (hasSameName(variableAffected, varInStatement)) {
+							aVarAppearLastAssign = false;
+						}
+					}
+
+					if (aStatement instanceof CtAssignment) {
+						CtAssignment assignment = (CtAssignment) aStatement;
+						if (assignment.getAssigned().toString()
+								.equals(variableAffected.getVariable().getSimpleName())) {
+							aVarAppearLastAssign = true;
+						}
+					}
+
+					if (aStatement instanceof CtLocalVariable) {
+						CtLocalVariable ctLocalVariable = (CtLocalVariable) aStatement;
+
+						if (ctLocalVariable.getReference().getSimpleName()
+								.equals(variableAffected.getVariable().getSimpleName()))
+							aVarAppearLastAssign = true;
+					}
+				}
+
+				// Now, let's check the type of the var to see if it's local or not
+				if (variableAffected.getVariable().getType() != null) {
+
+					if (!variableAffected.getVariable().getType().isPrimitive()) {
+						if (aVarAppearLastAssign)
+							objectsLastAssign++;
+						else
+							objectsLastUse++;
+
+					} else {
+
+						if (variableAffected.getVariable().getType().isPrimitive())
+							if (aVarAppearLastAssign)
+								primitiveLastAssign++;
+							else
+								primitiveLastUse++;
+					}
+				}
+
+				if (objectsLastAssign > 0 && primitiveLastAssign > 0)
+					break;
+			}
+
+			boolean[] expressionfeatures = new boolean[2];
+
+			expressionfeatures[0] = (objectsLastAssign > 0);
+			expressionfeatures[1] = (primitiveLastAssign > 0);
+
+			return expressionfeatures;
+
+		} catch (Throwable e) {
+			e.printStackTrace();
+		}
+
+		boolean[] expressionfeaturesdefault = new boolean[2];
+		expressionfeaturesdefault[0] = false;
+		expressionfeaturesdefault[1] = false;
+
+		return expressionfeaturesdefault;
+	}
+
+	public boolean[] analyze_SamerMethodWithGuardOrTrywrap(CtElement element, CtClass parentClass,
+			List<CtInvocation> allinvocationsFromClass, List<CtInvocation> invocationstostudy,
+			List<CtConstructorCall> allconstructorcallsFromClass, List<CtConstructorCall> constructorcallstostudy) {
+
 		try {
 
 			boolean S9anyhasNormalGuard = false;
 			boolean S10anyhasNULLGuard = false;
 
 			for (CtInvocation invocation : invocationstostudy) {
-				
+
 				CtStatement parent = invocation.getParent(new LineFilter());
-				
-				if(isNormalGuard(invocation, (parent)) || isNullCheckGuard(invocation, (parent)))
+
+				if (isNormalGuard(invocation, (parent)) || isNullCheckGuard(invocation, (parent)))
 					continue;
-				
+
 				// For each method in the class
 				for (CtInvocation specificinvocation : allinvocationsFromClass) {
 
-					if(invocation.equals(specificinvocation))
+					if (invocation.equals(specificinvocation))
 						continue;
-					
-					if(invocation.getExecutable().getSimpleName().equals
-							(specificinvocation.getExecutable().getSimpleName())) {
-						
+
+					if (invocation.getExecutable().getSimpleName()
+							.equals(specificinvocation.getExecutable().getSimpleName())) {
+
 						CtStatement specificparent = specificinvocation.getParent(new LineFilter());
 
 						if (isNormalGuard(specificinvocation, (specificparent)))
-							S9anyhasNormalGuard =true;
-						
+							S9anyhasNormalGuard = true;
+
 						if (isNullCheckGuard(specificinvocation, (specificparent)))
-							S10anyhasNULLGuard =true;
+							S10anyhasNULLGuard = true;
 					}
-					
-					if(S9anyhasNormalGuard && S10anyhasNULLGuard)
+
+					if (S9anyhasNormalGuard && S10anyhasNULLGuard)
 						break;
-				}	
-				
-				if(S9anyhasNormalGuard && S10anyhasNULLGuard)
+				}
+
+				if (S9anyhasNormalGuard && S10anyhasNULLGuard)
 					break;
 			} // end invocation
-			
-			if(!(S9anyhasNormalGuard && S10anyhasNULLGuard)) {
-              for (CtConstructorCall constructorcall : constructorcallstostudy) {
-				
-				CtStatement parent = constructorcall.getParent(new LineFilter());
-				
-				if(isNormalGuard(constructorcall, (parent)) || isNullCheckGuard(constructorcall, (parent)))
-					continue;
-				
-				// For each method in the class
-				for (CtConstructorCall specificconstructorcall : allconstructorcallsFromClass) {
 
-					if(constructorcall.equals(specificconstructorcall))
+			if (!(S9anyhasNormalGuard && S10anyhasNULLGuard)) {
+				for (CtConstructorCall constructorcall : constructorcallstostudy) {
+
+					CtStatement parent = constructorcall.getParent(new LineFilter());
+
+					if (isNormalGuard(constructorcall, (parent)) || isNullCheckGuard(constructorcall, (parent)))
 						continue;
-					
-					if(getSimplenameForConstructorCall(constructorcall).equals
-							(getSimplenameForConstructorCall(specificconstructorcall))) {
-						
-						CtStatement specificparent = specificconstructorcall.getParent(new LineFilter());
 
-						if (isNormalGuard(specificconstructorcall, (specificparent)))
-							S9anyhasNormalGuard =true;
-						
-						if (isNullCheckGuard(specificconstructorcall, (specificparent)))
-							S10anyhasNULLGuard =true;
+					// For each method in the class
+					for (CtConstructorCall specificconstructorcall : allconstructorcallsFromClass) {
+
+						if (constructorcall.equals(specificconstructorcall))
+							continue;
+
+						if (getSimplenameForConstructorCall(constructorcall)
+								.equals(getSimplenameForConstructorCall(specificconstructorcall))) {
+
+							CtStatement specificparent = specificconstructorcall.getParent(new LineFilter());
+
+							if (isNormalGuard(specificconstructorcall, (specificparent)))
+								S9anyhasNormalGuard = true;
+
+							if (isNullCheckGuard(specificconstructorcall, (specificparent)))
+								S10anyhasNULLGuard = true;
+						}
+
+						if (S9anyhasNormalGuard && S10anyhasNULLGuard)
+							break;
 					}
-					
-					if(S9anyhasNormalGuard && S10anyhasNULLGuard)
+
+					if (S9anyhasNormalGuard && S10anyhasNULLGuard)
 						break;
-				 }	
-				
-				if(S9anyhasNormalGuard && S10anyhasNULLGuard)
-					break;
-			   } 
+				}
 			}
-			
+
 			boolean S12anyhasTryCatch = false;
 
-            for (CtInvocation invocation : invocationstostudy) {
-            	
+			for (CtInvocation invocation : invocationstostudy) {
+
 				CtStatement parent = invocation.getParent(new LineFilter());
-				
+
 				CtTry potentionalTryCatch = invocation.getParent(CtTry.class);
-				
-				if(potentionalTryCatch != null && whethereffectivetrycatch (potentionalTryCatch,parent))
+
+				if (potentionalTryCatch != null && whethereffectivetrycatch(potentionalTryCatch, parent))
 					continue;
-				
+
 				// For each method in the class
 				for (CtInvocation specificinvocation : allinvocationsFromClass) {
 
-					if(invocation.equals(specificinvocation))
+					if (invocation.equals(specificinvocation))
 						continue;
-					
-					if(invocation.getExecutable().getSimpleName().equals
-							(specificinvocation.getExecutable().getSimpleName())) {
-						
+
+					if (invocation.getExecutable().getSimpleName()
+							.equals(specificinvocation.getExecutable().getSimpleName())) {
+
 						CtStatement parentspecific = specificinvocation.getParent(new LineFilter());
-						
+
 						CtTry potentionalTryCatchspecific = specificinvocation.getParent(CtTry.class);
-						
-						if(potentionalTryCatchspecific != null && 
-								whethereffectivetrycatch (potentionalTryCatchspecific, parentspecific))
+
+						if (potentionalTryCatchspecific != null
+								&& whethereffectivetrycatch(potentionalTryCatchspecific, parentspecific))
 							S12anyhasTryCatch = true;
 					}
-					
-					if(S12anyhasTryCatch)
+
+					if (S12anyhasTryCatch)
 						break;
-				}	
-				
-				if(S12anyhasTryCatch)
+				}
+
+				if (S12anyhasTryCatch)
 					break;
 			} // end invocation
-            
-            if(!S12anyhasTryCatch) {
-              for (CtConstructorCall constructorcall : constructorcallstostudy) {
-				
-                CtStatement parent = constructorcall.getParent(new LineFilter());
-				
-				CtTry potentionalTryCatch = constructorcall.getParent(CtTry.class);
-				
-				if(potentionalTryCatch != null && whethereffectivetrycatch (potentionalTryCatch, parent))
-					continue;
-				
-				// For each method in the class
-				for (CtConstructorCall specificconstructorcall : allconstructorcallsFromClass) {
 
-					if(constructorcall.equals(specificconstructorcall))
+			if (!S12anyhasTryCatch) {
+				for (CtConstructorCall constructorcall : constructorcallstostudy) {
+
+					CtStatement parent = constructorcall.getParent(new LineFilter());
+
+					CtTry potentionalTryCatch = constructorcall.getParent(CtTry.class);
+
+					if (potentionalTryCatch != null && whethereffectivetrycatch(potentionalTryCatch, parent))
 						continue;
-					
-					if(getSimplenameForConstructorCall(constructorcall).equals
-							(getSimplenameForConstructorCall(specificconstructorcall))) {
-						
-						CtStatement parentspecific = specificconstructorcall.getParent(new LineFilter());
-						
-						CtTry potentionalTryCatchspecific = specificconstructorcall.getParent(CtTry.class);
-						
-						if(potentionalTryCatchspecific != null && 
-								whethereffectivetrycatch (potentionalTryCatchspecific, parentspecific))
-							S12anyhasTryCatch = true;
+
+					// For each method in the class
+					for (CtConstructorCall specificconstructorcall : allconstructorcallsFromClass) {
+
+						if (constructorcall.equals(specificconstructorcall))
+							continue;
+
+						if (getSimplenameForConstructorCall(constructorcall)
+								.equals(getSimplenameForConstructorCall(specificconstructorcall))) {
+
+							CtStatement parentspecific = specificconstructorcall.getParent(new LineFilter());
+
+							CtTry potentionalTryCatchspecific = specificconstructorcall.getParent(CtTry.class);
+
+							if (potentionalTryCatchspecific != null
+									&& whethereffectivetrycatch(potentionalTryCatchspecific, parentspecific))
+								S12anyhasTryCatch = true;
+						}
+
+						if (S12anyhasTryCatch)
+							break;
 					}
-				
-					if(S12anyhasTryCatch)
+
+					if (S12anyhasTryCatch)
 						break;
-				}	
-				
-				if(S12anyhasTryCatch)
-					break;
-			  }
-            }
-			
-			boolean[] expressionfeatures=new boolean[3];
-			
+				}
+			}
+
+			boolean[] expressionfeatures = new boolean[3];
+
 			expressionfeatures[0] = S9anyhasNormalGuard;
 			expressionfeatures[1] = S10anyhasNULLGuard;
 			expressionfeatures[2] = S12anyhasTryCatch;
 
-            return expressionfeatures;
-            
+			return expressionfeatures;
+
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}
-		
-		boolean[] expressionfeaturesdefault=new boolean[3];
-		
+
+		boolean[] expressionfeaturesdefault = new boolean[3];
+
 		expressionfeaturesdefault[0] = false;
 		expressionfeaturesdefault[1] = false;
 		expressionfeaturesdefault[2] = false;
-		 
+
 		return expressionfeaturesdefault;
 	}
- 	
- 	public static boolean whethereffectivetrycatch (CtTry trystatement, CtStatement targetstatement) {
- 			
- 			CtBlock tryblock=trystatement.getBody();
- 			
- 			if(tryblock!=null) {
- 				List<CtStatement> trystatements=tryblock.getStatements();
- 			//	if(trystatements.size()>0 && trystatements.get(0)==targetstatement)
- 	            if(trystatements.size() > 0)
- 					return true;
- 			}
- 			
- 			return false;
- 	}
- 	
- 	/**
+
+	public static boolean whethereffectivetrycatch(CtTry trystatement, CtStatement targetstatement) {
+
+		CtBlock tryblock = trystatement.getBody();
+
+		if (tryblock != null) {
+			List<CtStatement> trystatements = tryblock.getStatements();
+			// if(trystatements.size()>0 && trystatements.get(0)==targetstatement)
+			if (trystatements.size() > 0)
+				return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check if a method declaration has a parameter compatible and return with the
 	 * cttype as argument
 	 * 
@@ -1137,84 +1148,83 @@ public abstract class AbstractCodeAnalyzer {
 
 				if (compareTypes(typeToMatch, parameter.getType())
 						&& compareTypes(typeToMatch, anotherMethodInBuggyClass.getType())) {
-				
+
 					return anotherMethodInBuggyClass;
 				}
 			}
 		}
-		
+
 		return null;
 	}
-	
+
 	public CtInvocation checkInvocationWithParameterReturnCompatibleType(List<CtInvocation> invocationsFromClass,
 			CtTypeReference type, CtClass parentclass) {
-		
-		List<CtBinaryOperator> binaryOperatorInClass = parentclass.getElements(e -> 
-		(e instanceof CtBinaryOperator)).stream()
-				.map(CtBinaryOperator.class::cast).collect(Collectors.toList());
-		
+
+		List<CtBinaryOperator> binaryOperatorInClass = parentclass.getElements(e -> (e instanceof CtBinaryOperator))
+				.stream().map(CtBinaryOperator.class::cast).collect(Collectors.toList());
+
 		for (CtInvocation anInvocation : invocationsFromClass) {
-			
+
 			List<CtTypeReference> inferredpotentionaltypes = new ArrayList<CtTypeReference>();
 			inferredpotentionaltypes.clear();
-			
-			CtTypeReference inferredtype = null;
-			if(anInvocation.getType()==null) {
-				for(CtBinaryOperator certainbinary: binaryOperatorInClass) {
-					if(certainbinary.getLeftHandOperand() instanceof CtInvocation) {
 
-						CtInvocation anotherinvocation=(CtInvocation)certainbinary.getLeftHandOperand();
-						if(anotherinvocation.getExecutable().getSignature().equals(anInvocation.getExecutable().getSignature())
-								&& certainbinary.getRightHandOperand().getType()!=null) {
-							 inferredtype=certainbinary.getRightHandOperand().getType();
-							 inferredpotentionaltypes.add(inferredtype);
-							 break;
+			CtTypeReference inferredtype = null;
+			if (anInvocation.getType() == null) {
+				for (CtBinaryOperator certainbinary : binaryOperatorInClass) {
+					if (certainbinary.getLeftHandOperand() instanceof CtInvocation) {
+
+						CtInvocation anotherinvocation = (CtInvocation) certainbinary.getLeftHandOperand();
+						if (anotherinvocation.getExecutable().getSignature()
+								.equals(anInvocation.getExecutable().getSignature())
+								&& certainbinary.getRightHandOperand().getType() != null) {
+							inferredtype = certainbinary.getRightHandOperand().getType();
+							inferredpotentionaltypes.add(inferredtype);
+							break;
 						}
 					}
-					
-					if(certainbinary.getRightHandOperand() instanceof CtInvocation) {
-						CtInvocation anotherinvocation=(CtInvocation)certainbinary.getRightHandOperand();
-						if(anotherinvocation.getExecutable().getSignature().equals(anInvocation.getExecutable().getSignature())
-								&& certainbinary.getLeftHandOperand().getType()!=null) {
-							 inferredtype=certainbinary.getLeftHandOperand().getType();
-							 inferredpotentionaltypes.add(inferredtype);
-							 break;
+
+					if (certainbinary.getRightHandOperand() instanceof CtInvocation) {
+						CtInvocation anotherinvocation = (CtInvocation) certainbinary.getRightHandOperand();
+						if (anotherinvocation.getExecutable().getSignature()
+								.equals(anInvocation.getExecutable().getSignature())
+								&& certainbinary.getLeftHandOperand().getType() != null) {
+							inferredtype = certainbinary.getLeftHandOperand().getType();
+							inferredpotentionaltypes.add(inferredtype);
+							break;
 						}
 					}
 				}
-				
-			} else inferredtype=anInvocation.getType();
-			
-			
+
+			} else
+				inferredtype = anInvocation.getType();
+
 			if (compareTypes(type, inferredtype) || compareInferredTypes(type, inferredpotentionaltypes)) {
 
 				for (Object anObjArgument : anInvocation.getArguments()) {
 					CtExpression anArgument = (CtExpression) anObjArgument;
-					
+
 					if (compareTypes(type, anArgument.getType())) {
 						return anInvocation;
 					}
 				}
 			}
 		}
-		
+
 		return null;
 	}
-	
 
-    public static boolean compareInferredTypes(CtTypeReference t1, List<CtTypeReference> potentionaltypes) {
-		
-		for(int i=0; i<potentionaltypes.size(); i++) {
-			if(compareTypes(t1, potentionaltypes.get(i)))
+	public static boolean compareInferredTypes(CtTypeReference t1, List<CtTypeReference> potentionaltypes) {
+
+		for (int i = 0; i < potentionaltypes.size(); i++) {
+			if (compareTypes(t1, potentionaltypes.get(i)))
 				return true;
 		}
-	    
+
 		return false;
 	}
-    
-	public CtMethod checkMethodDeclarationWithParemetrCompatibleType (List allMethods,
-			CtTypeReference typeToMatch) {
-		
+
+	public CtMethod checkMethodDeclarationWithParemetrCompatibleType(List allMethods, CtTypeReference typeToMatch) {
+
 		for (Object omethod : allMethods) {
 
 			if (!(omethod instanceof CtMethod))
@@ -1226,122 +1236,118 @@ public abstract class AbstractCodeAnalyzer {
 				CtParameter parameter = (CtParameter) oparameter;
 
 				if (compareTypes(typeToMatch, parameter.getType())) {
-				
+
 					return anotherMethodInBuggyClass;
 				}
 			}
 		}
-		
+
 		return null;
 	}
-	
-	public CtInvocation checkInvocationWithParemetrCompatibleType (List<CtInvocation> invocationsFromClass,
+
+	public CtInvocation checkInvocationWithParemetrCompatibleType(List<CtInvocation> invocationsFromClass,
 			CtTypeReference type) {
-		
+
 		for (CtInvocation anInvocation : invocationsFromClass) {
 
 			for (Object anObjArgument : anInvocation.getArguments()) {
 				CtExpression anArgument = (CtExpression) anObjArgument;
-					
+
 				if (compareTypes(type, anArgument.getType())) {
-						return anInvocation;
+					return anInvocation;
 				}
 			}
 		}
-		
+
 		return null;
 	}
-	
-	  public static String[] getLiteralTypeAndValue(CtLiteral inputLiteral) {
-			
-		    String[] literaltypeandvalue=new String[2];
-			
-			if(inputLiteral.toString().trim().startsWith("'")) {
-				literaltypeandvalue[0]="char";
-				literaltypeandvalue[1]=inputLiteral.getValue().toString();
+
+	public static String[] getLiteralTypeAndValue(CtLiteral inputLiteral) {
+
+		String[] literaltypeandvalue = new String[2];
+
+		if (inputLiteral.toString().trim().startsWith("'")) {
+			literaltypeandvalue[0] = "char";
+			literaltypeandvalue[1] = inputLiteral.getValue().toString();
+		} else if (inputLiteral.toString().trim().startsWith("\"")) {
+			literaltypeandvalue[0] = "string";
+			literaltypeandvalue[1] = inputLiteral.getValue().toString();
+		} else if (inputLiteral.toString().indexOf("null") != -1) {
+			literaltypeandvalue[0] = "null";
+			literaltypeandvalue[1] = "null";
+		} else {
+			if (inputLiteral.getValue().toString().equals("true")
+					|| inputLiteral.getValue().toString().equals("false")) {
+				literaltypeandvalue[0] = "boolean";
+				literaltypeandvalue[1] = inputLiteral.getValue().toString();
+			} else {
+				literaltypeandvalue[0] = "numerical";
+				literaltypeandvalue[1] = inputLiteral.getValue().toString();
 			}
-			else if(inputLiteral.toString().trim().startsWith("\"")) {
-				literaltypeandvalue[0]="string";
-				literaltypeandvalue[1]=inputLiteral.getValue().toString();
-			}
-			else if(inputLiteral.toString().indexOf("null")!=-1) {
-				literaltypeandvalue[0]="null";
-				literaltypeandvalue[1]="null";
-			}
-			else {
-				if(inputLiteral.getValue().toString().equals("true")||inputLiteral.getValue().toString().equals("false")) {
-					literaltypeandvalue[0]="boolean";
-					literaltypeandvalue[1]=inputLiteral.getValue().toString();
-				}
-				else  {
-					literaltypeandvalue[0]="numerical";
-					literaltypeandvalue[1]=inputLiteral.getValue().toString();
-				}
-		    }
+		}
 
-			return literaltypeandvalue;
-	 }
-	  
-	 public List<CtTypeReference> inferPotentionalTypes (CtInvocation ainvocation,
-				CtClass parentclass) {
+		return literaltypeandvalue;
+	}
 
-			List<CtTypeReference> inferredpotentionaltypes = new ArrayList<CtTypeReference>();
+	public List<CtTypeReference> inferPotentionalTypes(CtInvocation ainvocation, CtClass parentclass) {
 
-			try {
-				List<CtBinaryOperator> binaryOperatorInClass = parentclass.getElements(e -> 
-				(e instanceof CtBinaryOperator)).stream()
-						.map(CtBinaryOperator.class::cast).collect(Collectors.toList());		
-				
-				inferredpotentionaltypes.clear();
-	               
-				CtTypeReference inferredtype = null;
-				if(ainvocation.getType()==null) {
-						for(CtBinaryOperator certainbinary: binaryOperatorInClass) {
-							if(certainbinary.getLeftHandOperand() instanceof CtInvocation) {
+		List<CtTypeReference> inferredpotentionaltypes = new ArrayList<CtTypeReference>();
 
-								CtInvocation anotherinvocation=(CtInvocation)certainbinary.getLeftHandOperand();
-								if(anotherinvocation.getExecutable().getSignature().equals(ainvocation.getExecutable().getSignature())
-										&& certainbinary.getRightHandOperand().getType()!=null) {
+		try {
+			List<CtBinaryOperator> binaryOperatorInClass = parentclass.getElements(e -> (e instanceof CtBinaryOperator))
+					.stream().map(CtBinaryOperator.class::cast).collect(Collectors.toList());
 
-									 inferredtype=certainbinary.getRightHandOperand().getType();
-									 inferredpotentionaltypes.add(inferredtype);
-									 break;
-								}
-							}
-							
-							if(certainbinary.getRightHandOperand() instanceof CtInvocation) {
-								CtInvocation anotherinvocation=(CtInvocation)certainbinary.getRightHandOperand();
-								if(anotherinvocation.getExecutable().getSignature().equals(ainvocation.getExecutable().getSignature())
-										&& certainbinary.getLeftHandOperand().getType()!=null) {
-									 inferredtype=certainbinary.getLeftHandOperand().getType();
-									 inferredpotentionaltypes.add(inferredtype);
-									 break;
-								}
-							}
-					 }	
-				} 		
-			  } catch (Exception ex) {
-			}
-			
-			return inferredpotentionaltypes;
-	 } 
-	 
+			inferredpotentionaltypes.clear();
 
-	 public boolean whetherhasobjective(List<CtTypeReference> inferredtypes) {
-			
-			for (int index=0; index<inferredtypes.size(); index++) {
-				
-				if(!inferredtypes.get(index).isPrimitive()) {
-					return true;
+			CtTypeReference inferredtype = null;
+			if (ainvocation.getType() == null) {
+				for (CtBinaryOperator certainbinary : binaryOperatorInClass) {
+					if (certainbinary.getLeftHandOperand() instanceof CtInvocation) {
+
+						CtInvocation anotherinvocation = (CtInvocation) certainbinary.getLeftHandOperand();
+						if (anotherinvocation.getExecutable().getSignature()
+								.equals(ainvocation.getExecutable().getSignature())
+								&& certainbinary.getRightHandOperand().getType() != null) {
+
+							inferredtype = certainbinary.getRightHandOperand().getType();
+							inferredpotentionaltypes.add(inferredtype);
+							break;
+						}
+					}
+
+					if (certainbinary.getRightHandOperand() instanceof CtInvocation) {
+						CtInvocation anotherinvocation = (CtInvocation) certainbinary.getRightHandOperand();
+						if (anotherinvocation.getExecutable().getSignature()
+								.equals(ainvocation.getExecutable().getSignature())
+								&& certainbinary.getLeftHandOperand().getType() != null) {
+							inferredtype = certainbinary.getLeftHandOperand().getType();
+							inferredpotentionaltypes.add(inferredtype);
+							break;
+						}
+					}
 				}
 			}
-			return false;
-	 }
-	 
-	 public String getSimplenameForConstructorCall (CtConstructorCall call) {
-		 
-		   String[] namespace= call.getType().getQualifiedName().split("\\(")[0].split("\\.");
-		   String constructorname =namespace [namespace.length-1];	
-		   return constructorname;
-	 }
+		} catch (Exception ex) {
+		}
+
+		return inferredpotentionaltypes;
+	}
+
+	public boolean whetherhasobjective(List<CtTypeReference> inferredtypes) {
+
+		for (int index = 0; index < inferredtypes.size(); index++) {
+
+			if (!inferredtypes.get(index).isPrimitive()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public String getSimplenameForConstructorCall(CtConstructorCall call) {
+
+		String[] namespace = call.getType().getQualifiedName().split("\\(")[0].split("\\.");
+		String constructorname = namespace[namespace.length - 1];
+		return constructorname;
+	}
 }


### PR DESCRIPTION
element. The current implementation finds the label in the GT node.
Thus, now  we return the toString of the element when there is not gt
node.