### PR TITLE
prepared for execution on bears dataset repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
 			<artifactId>org.eclipse.jgit</artifactId>
 			<version>3.5.3.201412180710-r</version>
 		</dependency>
+		<!-- <dependency>
+		    <groupId>org.eclipse.jgit</groupId>
+		    <artifactId>org.eclipse.jgit</artifactId>
+		    <version>5.6.0.201912101111-r</version>
+		</dependency> -->
+		
 		<dependency>
 			<groupId>org.gitective</groupId>
 			<artifactId>gitective-core</artifactId>

--- a/src/main/java/fr/inria/coming/changeminer/analyzer/instancedetector/ChangePatternInstance.java
+++ b/src/main/java/fr/inria/coming/changeminer/analyzer/instancedetector/ChangePatternInstance.java
@@ -83,7 +83,11 @@ public class ChangePatternInstance {
 
 	@Override
 	public String toString() {
-		return "ChangePatternInstance [actions=" + actions + "]";
+		try {
+			return "ChangePatternInstance [actions=" + actions + "]";
+		} catch (Exception e) {
+			return "";
+		}
 	}
 
 	public Map<PatternAction, MatchingAction> getMapping() {

--- a/src/main/java/fr/inria/coming/repairability/repairtools/Arja.java
+++ b/src/main/java/fr/inria/coming/repairability/repairtools/Arja.java
@@ -85,7 +85,12 @@ public class Arja extends AbstractRepairTool {
 				if (!mapping.hasSrc(((Insert) op.getAction()).getParent()))
 					return false;
 
-				CtElement srcRoot = ASTInfoResolver.getRootNode(((InsertOperation) op).getParent());
+				CtElement parentOfInsertedNode = ((InsertOperation) op).getParent();
+				
+				if(parentOfInsertedNode == null) // smallcreep__cucumber-seeds
+					return false;
+
+				CtElement srcRoot = ASTInfoResolver.getRootNode(parentOfInsertedNode);
 				return canBeReproducedFromSrc(srcRoot, (CtStatement) op.getSrcNode());
 			} else if (op instanceof UpdateOperation) {
 				return canBeReproducedFromSrc(ASTInfoResolver.getRootNode(op.getSrcNode()),
@@ -136,8 +141,13 @@ public class Arja extends AbstractRepairTool {
 				// the inserted node is a part of a parent inserted node
 				return false;
 			
+			CtElement insertedNodeParent = ((InsertOperation)insOp).getParent();
+			
+			if(insertedNodeParent == null)
+				return false;
+			
 			List<CtElement> insPars =
-					ASTInfoResolver.getNSubsequentParents(((InsertOperation)insOp).getParent(), INS_DEL_COMMON_PAR_HEIGHT), 
+					ASTInfoResolver.getNSubsequentParents(insertedNodeParent, INS_DEL_COMMON_PAR_HEIGHT), 
 					delPars = ASTInfoResolver.getNSubsequentParents(delOp.getSrcNode(), INS_DEL_COMMON_PAR_HEIGHT);
 			
 			Set<CtElement> insDistinctParsSet = new HashSet<CtElement>();
@@ -147,7 +157,7 @@ public class Arja extends AbstractRepairTool {
 			if (insDistinctParsSet.size() == insPars.size())
                 return false;
 
-			CtElement srcRoot = ASTInfoResolver.getRootNode(((InsertOperation) op).getParent());
+			CtElement srcRoot = ASTInfoResolver.getRootNode(insertedNodeParent);
 			return canBeReproducedFromSrc(srcRoot, (CtStatement) op.getSrcNode());
 		}
 

--- a/src/main/java/fr/inria/coming/repairability/repairtools/JGenProg.java
+++ b/src/main/java/fr/inria/coming/repairability/repairtools/JGenProg.java
@@ -101,7 +101,12 @@ public class JGenProg extends AbstractRepairTool {
 
         String elementStr = element.toString();
         for (CtElement srcElement : allSrcElements) {
-            String srcElementStr = srcElement.toString();
+        	String srcElementStr;
+        	try {
+        		srcElementStr = srcElement.toString();
+        	}catch(Exception e) {
+        		continue; // ex.: on "org-tigris-jsapar__jsapar" repo
+        	}
             if (srcElementStr.equals(elementStr))
                 return true;
             else if (srcElementStr.replace(elementStr, "").trim().equals(elementStr.trim()))

--- a/src/main/java/fr/inria/coming/utils/EntityTypesInfoResolver.java
+++ b/src/main/java/fr/inria/coming/utils/EntityTypesInfoResolver.java
@@ -32,8 +32,8 @@ public class EntityTypesInfoResolver {
     private void loadChildrenToParentsRelationsBetweenEntityTypes() {
         childrenToParentsRelationsBetweenEntityTypes = new HashMap<>();
         try {
-//        	Scanner sc = new Scanner(new File(getClass().getClassLoader().getResource(CLASSES_HIERARCHY_FILE_NAME).getFile()));
-        	Scanner sc = new Scanner(new File("/data/template-based/coming-test/data.txt"));
+        	Scanner sc = new Scanner(new File(getClass().getClassLoader().getResource(CLASSES_HIERARCHY_FILE_NAME).getFile()));
+//        	Scanner sc = new Scanner(new File("/data/template-based/coming-test/data.txt"));
 
             while (sc.hasNextLine()) {
                 String line = sc.nextLine();

--- a/src/main/java/fr/inria/coming/utils/EntityTypesInfoResolver.java
+++ b/src/main/java/fr/inria/coming/utils/EntityTypesInfoResolver.java
@@ -32,7 +32,8 @@ public class EntityTypesInfoResolver {
     private void loadChildrenToParentsRelationsBetweenEntityTypes() {
         childrenToParentsRelationsBetweenEntityTypes = new HashMap<>();
         try {
-        	Scanner sc = new Scanner(new File(getClass().getClassLoader().getResource(CLASSES_HIERARCHY_FILE_NAME).getFile()));
+//        	Scanner sc = new Scanner(new File(getClass().getClassLoader().getResource(CLASSES_HIERARCHY_FILE_NAME).getFile()));
+        	Scanner sc = new Scanner(new File("/data/template-based/coming-test/data.txt"));
 
             while (sc.hasNextLine()) {
                 String line = sc.nextLine();


### PR DESCRIPTION
Hi @martinezmatias & @monperrus 

Here, some minor bugs are fixed before running the experiment on BEARS dataset repositories.

Also, there seems to be a bug in Operation.toString() function (from [gum-tree-ast-diff project](https://github.com/SpoonLabs/gumtree-spoon-ast-diff)) that sometimes causes NullPointerException. For the moment, I added a [try & catch](https://github.com/khaes-kth/coming/blob/revision/FixForExec/src/main/java/fr/inria/coming/changeminer/analyzer/instancedetector/ChangePatternInstance.java#L86) to skip using this function so that we can run our experiment. I will add an issue to the project later.