### PR TITLE
BugFix: fix the bug for generating code features

### DIFF
--- a/src/main/java/fr/inria/coming/codefeatures/P4JFeatureAnalyzer.java
+++ b/src/main/java/fr/inria/coming/codefeatures/P4JFeatureAnalyzer.java
@@ -67,7 +67,8 @@ public class P4JFeatureAnalyzer implements Analyzer<IRevision> {
 
 		Option option = new Option();
 		option.featureOption = FeatureOption.ORIGINAL;
-		CodeDiffer codeDiffer = new CodeDiffer(true, option);
+		//We set the first parameter of CodeDiffer as False to not allow the code generation at buggy location
+		CodeDiffer codeDiffer = new CodeDiffer(false, option);
 		//Get feature matrix
 		List<FeatureMatrix> featureMatrix = codeDiffer.runByGenerator(src, target);
 		//Get feature vector
@@ -120,7 +121,8 @@ public class P4JFeatureAnalyzer implements Analyzer<IRevision> {
             List<String> valueList = null;
 	        List<String> header = new ArrayList<>();
 	        List<String> values = new ArrayList<>();
-           
+	        JsonObject jsonfile = new JsonObject();
+
 	        //Initial all vector  as 0.
 	        for (int idx = 0; idx < parameterVector.size(); idx++) {
 	            FeatureCross featureCross;
@@ -138,13 +140,13 @@ public class P4JFeatureAnalyzer implements Analyzer<IRevision> {
                         valueList.set(featureCross.getId(), "1");
                     }
                 }
+                
+                for (int idx = 0; idx < parameterVector.size(); idx++) {
+    	        			jsonfile.addProperty(header.get(idx), valueList.get(idx));
+    	        		}
             }
              
-	        JsonObject jsonfile = new JsonObject();
-	        for (int idx = 0; idx < parameterVector.size(); idx++) {
-	        	jsonfile.addProperty(header.get(idx), valueList.get(idx));
-	        }
-	       
+	               
 	       return jsonfile;
 	        
 	    }

--- a/src/main/java/fr/inria/coming/core/entities/output/FeaturesOutput.java
+++ b/src/main/java/fr/inria/coming/core/entities/output/FeaturesOutput.java
@@ -41,7 +41,7 @@ public class FeaturesOutput implements IOutput {
 				continue;
 
 			FeaturesResult result = (FeaturesResult) rv.getResultFromClass(FeatureAnalyzer.class);
-			save(result,"");
+			save(result,"S4R");
 		}
 
 	}

--- a/src/main/java/fr/inria/coming/core/entities/output/FeaturesOutput.java
+++ b/src/main/java/fr/inria/coming/core/entities/output/FeaturesOutput.java
@@ -47,6 +47,11 @@ public class FeaturesOutput implements IOutput {
 	}
 
 	public JsonElement save(FeaturesResult result, String featureType) {
+		if (result == null || "".equals(featureType)) {
+			log.debug("No Code Change feature captured");
+			return null;
+		}
+		
 		JsonElement file = result.getFeatures();
 
 		FileWriter fw;

--- a/src/test/java/fr/inria/coming/spoon/core/MainComingTest.java
+++ b/src/test/java/fr/inria/coming/spoon/core/MainComingTest.java
@@ -107,14 +107,14 @@ public class MainComingTest {
 
 	@Test
 	public void testFeaturesMain() throws Exception {
-		File output = new File("./coming_results/features_fe76517014e580ddcb40ac04ea824d54ba741c8b.json");
+		File output = new File("./coming_results/S4Rfeatures_fe76517014e580ddcb40ac04ea824d54ba741c8b.json");
 
 		// clean test data
 		output.delete();
 
 		assertFalse(output.exists());
 
-		FinalResult r = new ComingMain().run(new String[] { "-mode", "features", "-location", "repogit4testv0" });
+		FinalResult r = new ComingMain().run(new String[] { "-mode", "features",  "-location", "repogit4testv0" });
 
 		// the JSON file has been created
 		assertTrue(output.exists());

--- a/src/test/java/fr/inria/coming/spoon/features/FeaturesOnComingMainTest.java
+++ b/src/test/java/fr/inria/coming/spoon/features/FeaturesOnComingMainTest.java
@@ -101,19 +101,16 @@ public class FeaturesOnComingMainTest {
 	}
 
 	/**
-	 * We ignore the execution of this test case: it takes hours, it does only
-	 * compute the features but it does not assert the behaviour
+	 *  Unit test to extract S4R code features
 	 * 
-	 * @throws Exception
 	 */
 	@Test
-	@Ignore
 	public void testFeaturesOnS4REvolutionFromFolder1() throws Exception {
 		ComingMain main = new ComingMain();
 
 		CommandSummary cs = new CommandSummary();
 		cs.append("-input", "files");
-		cs.append("-location", (new File("src/main/resources/Defects4J_all_pairs")).getAbsolutePath());
+		cs.append("-location", (new File("src/main/resources/pairsD4j")).getAbsolutePath());
 		cs.append("-mode", "features");
 		cs.append("-featuretype", "S4R");
 		cs.append("-output", "./out_features_d4j");
@@ -121,41 +118,24 @@ public class FeaturesOnComingMainTest {
 		FinalResult finalResult = null;
 
 		finalResult = main.run(cs.flat());
-
-		CommitFinalResult commitResult = (CommitFinalResult) finalResult;
-
-		assertTrue(commitResult.getAllResults().values().size() > 0);
-
-		for (Commit iCommit : commitResult.getAllResults().keySet()) {
-
-			RevisionResult resultofCommit = commitResult.getAllResults().get(iCommit);
-			// Get the results of this analyzer
-			AnalysisResult featureResult = resultofCommit.get(FeatureAnalyzer.class.getSimpleName());
-
-			assertTrue(featureResult instanceof FeaturesResult);
-			FeaturesResult fresults = (FeaturesResult) featureResult;
-			assertNotNull(fresults);
-			assertNotNull(fresults.getFeatures());
-
-		}
+		//pairsD4j contains two file pairs, expected to output two JSON feature files.
+		assertTrue(finalResult.getAllResults().values().size() == 2);
+		
 
 	}
 	
 	
 	/**
-	 * We ignore the execution of this test case: it takes hours, it does only
-	 * compute the features but it does not assert the behaviour
+	 * Unit test to extract P4J code features
 	 * 
-	 * @throws Exception
 	 */
 	@Test
-	@Ignore
 	public void testFeaturesOnP4JEvolutionFromFolder1() throws Exception {
 		ComingMain main = new ComingMain();
 
 		CommandSummary cs = new CommandSummary();
 		cs.append("-input", "files");
-		cs.append("-location", (new File("src/main/resources/Defects4J_all_pairs")).getAbsolutePath());
+		cs.append("-location", (new File("src/main/resources/pairsD4j")).getAbsolutePath());
 		cs.append("-mode", "features");
 		cs.append("-featuretype", "P4J");
 		cs.append("-output", "./out_features_d4j");
@@ -163,24 +143,8 @@ public class FeaturesOnComingMainTest {
 		FinalResult finalResult = null;
 
 		finalResult = main.run(cs.flat());
-
-		CommitFinalResult commitResult = (CommitFinalResult) finalResult;
-
-		assertTrue(commitResult.getAllResults().values().size() > 0);
-
-		for (Commit iCommit : commitResult.getAllResults().keySet()) {
-
-			RevisionResult resultofCommit = commitResult.getAllResults().get(iCommit);
-			// Get the results of this analyzer
-			AnalysisResult featureResult = resultofCommit.get(FeatureAnalyzer.class.getSimpleName());
-
-			assertTrue(featureResult instanceof FeaturesResult);
-			FeaturesResult fresults = (FeaturesResult) featureResult;
-			assertNotNull(fresults);
-			assertNotNull(fresults.getFeatures());
-
-		}
-
+		//pairsD4j contains two file pairs, expected to output two JSON feature files.
+		assertTrue(finalResult.getAllResults().values().size() == 2);
 	}
 	
 


### PR DESCRIPTION
Hi @martinezmatias,

When I tried code extraction from the command line and unit tests, I encounter some bugs. So I am sending this PR to fix the bugs in feature generation.


First, in P4JFeatureAnalyzer.java, I change the setting of byGenerator = False in P4J, to disable P4J generating code on the buggy location. This version only returns the original diff features. And null pointer exceptions in the file.

Second, in FeaturesOutput.java, fixed another null pointer exception and avoid generate duplicate features when no feature type specified.

Third, I reopen two unit test cases to test the feature generation. They were ignored because of the it took quite long to generate features for folder " Defects4J_all_pairs". I  have updated to "pairsD4j" with only two diffs. Now, these two functions executed for 10 seconds. I think it would be good to have these two tests to specify the code feature functions.


