### PR TITLE
feat: add code to generate not crossed P4J features

### DIFF
--- a/src/main/java/fr/inria/coming/codefeatures/P4JFeatureAnalyzer.java
+++ b/src/main/java/fr/inria/coming/codefeatures/P4JFeatureAnalyzer.java
@@ -23,6 +23,7 @@ import fr.inria.coming.core.engine.Analyzer;
 import fr.inria.coming.core.entities.AnalysisResult;
 import fr.inria.coming.core.entities.DiffResult;
 import fr.inria.coming.core.entities.RevisionResult;
+import fr.inria.coming.main.ComingProperties;
 import fr.inria.prophet4j.feature.FeatureCross;
 import fr.inria.prophet4j.feature.extended.ExtendedFeatureCross;
 import fr.inria.prophet4j.feature.original.OriginalFeatureCross;
@@ -68,8 +69,8 @@ public class P4JFeatureAnalyzer implements Analyzer<IRevision> {
 		Option option = new Option();
 		option.featureOption = FeatureOption.ORIGINAL;
 		//We set the first parameter of CodeDiffer as False to not allow the code generation at buggy location
-		//The second false indicates cross features
-		Boolean cross = false;
+		//By default, coming extracts simple P4J features, so the cross sets to false
+		Boolean cross = ComingProperties.getPropertyBoolean("cross");
 		CodeDiffer codeDiffer = new CodeDiffer(false, option,cross);
 		//Get feature matrix
 		List<FeatureMatrix> featureMatrix = codeDiffer.runByGenerator(src, target);
@@ -78,7 +79,7 @@ public class P4JFeatureAnalyzer implements Analyzer<IRevision> {
 		if(cross) {
 			jsonfile = genVectorsCSV(option,target,featureMatrix);
 		} else {
-			jsonfile = getNonCrossJSON(option,target,featureMatrix);
+			jsonfile = getSimleP4JJSON(option,target,featureMatrix);
 		}
 		
 		JsonArray filesArray = new JsonArray();		
@@ -96,7 +97,7 @@ public class P4JFeatureAnalyzer implements Analyzer<IRevision> {
 
 	}
 
-	private JsonObject getNonCrossJSON(Option option, File target, List<FeatureMatrix> featureMatrix) {
+	private JsonObject getSimleP4JJSON(Option option, File target, List<FeatureMatrix> featureMatrix) {
 		 ParameterVector parameterVector = new ParameterVector(option.featureOption);
 	        JsonObject jsonfile = new JsonObject();
 	       

--- a/src/main/java/fr/inria/prophet4j/feature/FeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/FeatureExtractor.java
@@ -8,4 +8,5 @@ import spoon.reflect.declaration.*;
 public interface FeatureExtractor {
     // this is for CodeDiffer.java
     FeatureVector extractFeature(Repair repair, CtElement atom);
+    FeatureVector extractNonCrossFeature(Repair repair, CtElement atom);
 }

--- a/src/main/java/fr/inria/prophet4j/feature/FeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/FeatureExtractor.java
@@ -8,5 +8,5 @@ import spoon.reflect.declaration.*;
 public interface FeatureExtractor {
     // this is for CodeDiffer.java
     FeatureVector extractFeature(Repair repair, CtElement atom);
-    FeatureVector extractNonCrossFeature(Repair repair, CtElement atom);
+    FeatureVector extractSimpleP4JFeature(Repair repair, CtElement atom);
 }

--- a/src/main/java/fr/inria/prophet4j/feature/S4RO/S4ROFeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/S4RO/S4ROFeatureExtractor.java
@@ -376,4 +376,10 @@ public class S4ROFeatureExtractor implements FeatureExtractor {
         if (!repair.isReplace)
             stmtsL.add(srcElem);
     }
+
+	@Override
+	public FeatureVector extractNonCrossFeature(Repair repair, CtElement atom) {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/src/main/java/fr/inria/prophet4j/feature/S4RO/S4ROFeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/S4RO/S4ROFeatureExtractor.java
@@ -378,7 +378,7 @@ public class S4ROFeatureExtractor implements FeatureExtractor {
     }
 
 	@Override
-	public FeatureVector extractNonCrossFeature(Repair repair, CtElement atom) {
+	public FeatureVector extractSimpleP4JFeature(Repair repair, CtElement atom) {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/src/main/java/fr/inria/prophet4j/feature/enhanced/EnhancedFeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/enhanced/EnhancedFeatureExtractor.java
@@ -554,7 +554,7 @@ public class EnhancedFeatureExtractor implements FeatureExtractor {
     }
 
 	@Override
-	public FeatureVector extractNonCrossFeature(Repair repair, CtElement atom) {
+	public FeatureVector extractSimpleP4JFeature(Repair repair, CtElement atom) {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/src/main/java/fr/inria/prophet4j/feature/enhanced/EnhancedFeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/enhanced/EnhancedFeatureExtractor.java
@@ -552,4 +552,10 @@ public class EnhancedFeatureExtractor implements FeatureExtractor {
         if (!repair.isReplace)
             stmtsL.add(srcElem);
     }
+
+	@Override
+	public FeatureVector extractNonCrossFeature(Repair repair, CtElement atom) {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/src/main/java/fr/inria/prophet4j/feature/extended/ExtendedFeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/extended/ExtendedFeatureExtractor.java
@@ -449,7 +449,7 @@ public class ExtendedFeatureExtractor implements FeatureExtractor {
     }
 
 	@Override
-	public FeatureVector extractNonCrossFeature(Repair repair, CtElement atom) {
+	public FeatureVector extractSimpleP4JFeature(Repair repair, CtElement atom) {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/src/main/java/fr/inria/prophet4j/feature/extended/ExtendedFeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/extended/ExtendedFeatureExtractor.java
@@ -447,4 +447,10 @@ public class ExtendedFeatureExtractor implements FeatureExtractor {
         if (!repair.isReplace)
             stmtsL.add(srcElem);
     }
+
+	@Override
+	public FeatureVector extractNonCrossFeature(Repair repair, CtElement atom) {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeature.java
+++ b/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeature.java
@@ -18,6 +18,9 @@ public interface OriginalFeature extends Feature {
         POS_AF_RF_CT, // GlobalFeatureNum     = 3 * AtomFeatureNum * RepairFeatureNum
         POS_AF_AF_CT, // VarCrossFeatureNum   = 3 * AtomFeatureNum * AtomFeatureNum
         AF_VF_CT, // ValueCrossFeatureNum = AtomFeatureNum * ValueFeatureNum
+        SRC,
+        FORMER,
+        LATER
     }
 
     enum AtomicFeature implements OriginalFeature {

--- a/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeatureCross.java
+++ b/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeatureCross.java
@@ -14,6 +14,7 @@ public class OriginalFeatureCross implements FeatureCross, Serializable {
     private Integer id;
     private Double degree;
     private List<Feature> features;
+    private CrossType crossType;
 
     public OriginalFeatureCross(Integer id) {
         this(id, 1.0);
@@ -54,6 +55,7 @@ public class OriginalFeatureCross implements FeatureCross, Serializable {
     public OriginalFeatureCross(CrossType crossType, List<Feature> features) {
         this(crossType, features, 1.0);
     }
+    
 
     public OriginalFeatureCross(CrossType crossType, List<Feature> features, Double degree) {
         int ordinal0, ordinal1, ordinal2;
@@ -95,6 +97,7 @@ public class OriginalFeatureCross implements FeatureCross, Serializable {
         }
         this.degree = degree;
         this.features = features;
+        this.crossType = crossType;
     }
 
     public Integer getId() {
@@ -105,6 +108,10 @@ public class OriginalFeatureCross implements FeatureCross, Serializable {
         return degree;
     }
 
+    public String getCrossType() {
+        return this.crossType.toString();
+    }
+    
     public List<Feature> getFeatures() {
         return features;
     }

--- a/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeatureExtractor.java
@@ -304,9 +304,9 @@ public class OriginalFeatureExtractor implements FeatureExtractor {
     }
     
 	/**
-	 * This function returns non cross features
+	 * This function returns simple P4J features
 	 */
-	public FeatureVector extractNonCrossFeature(Repair repair, CtElement atom) {
+	public FeatureVector extractSimpleP4JFeature(Repair repair, CtElement atom) {
 		List<CtElement> stmtsC = getCurrentStmts(repair);
 		List<CtElement> stmtsF = new ArrayList<>();
 		List<CtElement> stmtsL = new ArrayList<>();

--- a/src/main/java/fr/inria/prophet4j/utility/CodeDiffer.java
+++ b/src/main/java/fr/inria/prophet4j/utility/CodeDiffer.java
@@ -50,12 +50,20 @@ public class CodeDiffer {
     private boolean byGenerator;
     private Option option;
     private String pathName;
+    private boolean cross=true;
     private static final Logger logger = LogManager.getLogger(CodeDiffer.class.getName());
 
     public CodeDiffer(boolean byGenerator, Option option) {
         this.byGenerator = byGenerator;
         this.option = option;
         this.pathName = "";
+    }
+    
+    public CodeDiffer(boolean byGenerator, Option option, boolean cross) {
+        this.byGenerator = byGenerator;
+        this.option = option;
+        this.pathName = "";
+        this.cross = cross;
     }
 
     public void setPathName(String pathName) {
@@ -424,7 +432,12 @@ public class CodeDiffer {
                             Repair repair = generator.obtainHumanRepair();
                             FeatureVector featureVector = new FeatureVector();
                             for (CtElement atom : repair.getCandidateAtoms()) {
+                            		if(cross) {
                                 featureVector.merge(featureExtractor.extractFeature(repair, atom));
+                            		} else {
+                            			featureVector = featureExtractor.extractNonCrossFeature(repair, atom);
+                                 break;
+                            		}
                             }
                             featureVectors.add(featureVector);
                         }

--- a/src/main/java/fr/inria/prophet4j/utility/CodeDiffer.java
+++ b/src/main/java/fr/inria/prophet4j/utility/CodeDiffer.java
@@ -435,7 +435,7 @@ public class CodeDiffer {
                             		if(cross) {
                                 featureVector.merge(featureExtractor.extractFeature(repair, atom));
                             		} else {
-                            			featureVector = featureExtractor.extractNonCrossFeature(repair, atom);
+                            			featureVector = featureExtractor.extractSimpleP4JFeature(repair, atom);
                                  break;
                             		}
                             }

--- a/src/main/java/fr/inria/prophet4j/utility/Structure.java
+++ b/src/main/java/fr/inria/prophet4j/utility/Structure.java
@@ -159,6 +159,11 @@ public interface Structure {
             list.sort(Comparator.comparingInt(FeatureCross::getId));
             return list;
         }
+        
+        public List<FeatureCross> getNonSortedFeatureCrosses() {
+            List<FeatureCross> list = new ArrayList<>(featureCrosses);
+            return list;
+        }
 
         public void merge(FeatureVector featureVector) {
             this.featureCrosses.addAll(featureVector.getFeatureCrosses());

--- a/src/main/resources/config-coming.properties
+++ b/src/main/resources/config-coming.properties
@@ -40,3 +40,5 @@ excludetests=false
 addchangeinfoonfeatures=true
 #By default, code comments are not considered
 processcomments=false
+#By default, coming extracts simple P4J features (do no consider the cross features)
+cross=false

--- a/src/test/java/fr/inria/coming/spoon/features/FeaturesOnComingMainTest.java
+++ b/src/test/java/fr/inria/coming/spoon/features/FeaturesOnComingMainTest.java
@@ -132,7 +132,6 @@ public class FeaturesOnComingMainTest {
 	@Test
 	public void testFeaturesOnP4JEvolutionFromFolder1() throws Exception {
 		ComingMain main = new ComingMain();
-
 		CommandSummary cs = new CommandSummary();
 		cs.append("-input", "files");
 		cs.append("-location", (new File("src/main/resources/pairsD4j")).getAbsolutePath());


### PR DESCRIPTION
Hi @martinezmatias，

In this commit, we added functions to extract not crossed features.  In the generated JSON files, the features are constructed into three keys: SRC, FORMER, and LATER, to indicate the features of the changed AST, three statement blocks in the AST former the changed AST and later. I did not delete any original code but add an option to configure crossed and non-crossed features.

In addition, I fixed the bug to obtain the former/later statements. They were the same as the changed statement. 