### PR TITLE
added two remove features for P4J

### DIFF
--- a/src/main/java/fr/inria/coming/core/engine/RevisionNavigationExperiment.java
+++ b/src/main/java/fr/inria/coming/core/engine/RevisionNavigationExperiment.java
@@ -107,6 +107,10 @@ public abstract class RevisionNavigationExperiment<R extends IRevision> {
         for (Iterator<R> iterator = it; iterator.hasNext(); ) {
 
             R oneRevision = iterator.next();
+            
+            if(null == oneRevision) {
+            		return processEnd();
+            }
 
             log.info("\n***********\nAnalyzing " + i + "/" + size + " " + oneRevision.getName());
 

--- a/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeature.java
+++ b/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeature.java
@@ -95,8 +95,17 @@ public interface OriginalFeature extends Feature {
          * ReplaceStringKind
          */
         REPLACE_STMT_RF,
-        // DELETE_STMT_RF, // case of delete one statement
-        // UNKNOWN_STMT_RF, // other unknown operations like moving one statement
+        /**
+         * deleting a guard condition from an existing statement (GuardRepair in Prophet4C)
+         * RemoveGuardKind
+         */
+        REMOVE_GUARD_RF,
+        /**
+         * replacing an existing statement 
+         * RemoveSTMTKind
+         */
+        REMOVE_STMT_RF
+       
     }
 
     enum ValueFeature implements OriginalFeature {

--- a/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeature.java
+++ b/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeature.java
@@ -99,13 +99,23 @@ public interface OriginalFeature extends Feature {
          * deleting a guard condition from an existing statement (GuardRepair in Prophet4C)
          * RemoveGuardKind
          */
-        REMOVE_GUARD_RF,
+        REMOVE_PARTIAL_IF,
         /**
          * replacing an existing statement 
          * RemoveSTMTKind
          */
-        REMOVE_STMT_RF
-       
+        REMOVE_STMT,
+        /**
+         * deleting a if condition and the block inside it from an existing statement (GuardRepair in Prophet4C)
+         * RemoveGuardBlockKind
+         */
+        REMOVE_WHOLE_IF,  
+        /**
+         * remove a whole block
+         */
+        REMOVE_WHOLE_BLOCK,
+        
+        
     }
 
     enum ValueFeature implements OriginalFeature {

--- a/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeatureExtractor.java
@@ -69,13 +69,19 @@ public class OriginalFeatureExtractor implements FeatureExtractor {
                 repairFeatures.add(RepairFeature.REPLACE_STMT_RF);
                 break;
              //Delete a guard in source file
-            case RemoveGuardKind:
-            	 	repairFeatures.add(RepairFeature.REMOVE_GUARD_RF);
+            case RemovePartialIFKind:
+            	 	repairFeatures.add(RepairFeature.REMOVE_PARTIAL_IF);
                 break;
              //Delete statements in source file
             case RemoveSTMTKind:
-	        	 	repairFeatures.add(RepairFeature.REMOVE_STMT_RF);
+	        	 	repairFeatures.add(RepairFeature.REMOVE_STMT);
 	            break;
+            case RemoveWholeIFKind:
+        	 	repairFeatures.add(RepairFeature.REMOVE_WHOLE_IF);
+            break;
+            case RemoveWholeBlockKind:
+        	 	repairFeatures.add(RepairFeature.REMOVE_WHOLE_BLOCK);
+            break;
         }
         return repairFeatures;
     }

--- a/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeatureExtractor.java
+++ b/src/main/java/fr/inria/prophet4j/feature/original/OriginalFeatureExtractor.java
@@ -68,6 +68,14 @@ public class OriginalFeatureExtractor implements FeatureExtractor {
                 // RepairFeature.REPLACE_STMT_RF == ReplaceStmtRepair
                 repairFeatures.add(RepairFeature.REPLACE_STMT_RF);
                 break;
+             //Delete a guard in source file
+            case RemoveGuardKind:
+            	 	repairFeatures.add(RepairFeature.REMOVE_GUARD_RF);
+                break;
+             //Delete statements in source file
+            case RemoveSTMTKind:
+	        	 	repairFeatures.add(RepairFeature.REMOVE_STMT_RF);
+	            break;
         }
         return repairFeatures;
     }

--- a/src/main/java/fr/inria/prophet4j/feature/original/OriginalRepairGenerator.java
+++ b/src/main/java/fr/inria/prophet4j/feature/original/OriginalRepairGenerator.java
@@ -9,9 +9,6 @@ import fr.inria.prophet4j.utility.Structure.DiffEntry;
 import fr.inria.prophet4j.feature.RepairGenerator;
 import fr.inria.prophet4j.feature.original.util.OriginalRepairAnalyzer;
 import spoon.Launcher;
-import spoon.reflect.code.CtIf;
-import spoon.reflect.code.CtStatement;
-import spoon.reflect.code.CtStatementList;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
@@ -294,13 +291,20 @@ public class OriginalRepairGenerator implements RepairGenerator {
         // todo improve
         // based on matchCandidateWithHumanFix()
         switch (diffEntry.type) {
-            case DeleteType: // kind
-                // GuardKind: // INSERT_GUARD_RF
-                repair.kind = RepairKind.RemoveSTMTKind;
-                if (diffEntry.srcNode instanceof CtIf) {
-                    repair.kind = RepairKind.RemoveGuardKind;
-                }
-                break;
+		case DeleteType: // only delete
+			repair.kind = RepairKind.RemoveSTMTKind;
+			if (diffEntry.srcNode instanceof CtIf) {
+				repair.kind = RepairKind.RemoveWholeIFKind;
+			} else if (diffEntry.srcNode instanceof CtBlock) {
+				repair.kind = RepairKind.RemoveWholeBlockKind;
+			}
+			break;
+		case PartialDeleteType: // delete + move kind
+			repair.kind = RepairKind.RemoveSTMTKind;
+			if (diffEntry.srcNode instanceof CtIf) {
+				repair.kind = RepairKind.RemovePartialIFKind;
+			}
+			break;
             case InsertType: // kind
                 // IfExitKind: // INSERT_CONTROL_RF
                 // AddAndReplaceKind: // INSERT_STMT_RF

--- a/src/main/java/fr/inria/prophet4j/feature/original/OriginalRepairGenerator.java
+++ b/src/main/java/fr/inria/prophet4j/feature/original/OriginalRepairGenerator.java
@@ -296,7 +296,10 @@ public class OriginalRepairGenerator implements RepairGenerator {
         switch (diffEntry.type) {
             case DeleteType: // kind
                 // GuardKind: // INSERT_GUARD_RF
-                repair.kind = RepairKind.GuardKind;
+                repair.kind = RepairKind.RemoveSTMTKind;
+                if (diffEntry.srcNode instanceof CtIf) {
+                    repair.kind = RepairKind.RemoveGuardKind;
+                }
                 break;
             case InsertType: // kind
                 // IfExitKind: // INSERT_CONTROL_RF

--- a/src/main/java/fr/inria/prophet4j/utility/CodeDiffer.java
+++ b/src/main/java/fr/inria/prophet4j/utility/CodeDiffer.java
@@ -149,8 +149,13 @@ public class CodeDiffer {
         Set<Integer> lineNums = new HashSet<>();
         lineNums.addAll(deleteOperations.keySet());
         lineNums.addAll(insertOperations.keySet());
+        Operation DEL = null;
         for (Integer lineNum : lineNums) {
-            Operation deleteOperation = deleteOperations.get(lineNum);
+        		Operation operation = deleteOperations.get(lineNum);       		
+        		if(operation!=null && "DEL".equals(operation.getAction().getName())) {
+        			DEL = operation;
+        		}       		 
+        	    Operation deleteOperation = deleteOperations.get(lineNum);
             Operation insertOperation = insertOperations.get(lineNum);
 
             DiffType type = null;
@@ -164,8 +169,18 @@ public class CodeDiffer {
                     dstNode = insertOperation.getSrcNode(); // ...
                 }
             } else if (deleteOperation != null) {
-                type = DiffType.DeleteType;
-                srcNode = deleteOperation.getSrcNode(); // ...
+            		Boolean pureDelete = true;
+            		for(Operation op :operations) {
+            			if(!"DEL".equals(op.getAction().getName())) {
+            				pureDelete = false;
+            			}
+            		}
+            		if(pureDelete) {
+            			type = DiffType.DeleteType;
+            		}else {
+            			type = DiffType.PartialDeleteType;
+            		}                                            
+                srcNode = DEL.getSrcNode(); // ...
                 dstNode = deleteOperation.getDstNode(); // null
                 if (srcNode == null) srcNode = dstNode;
                 if (dstNode == null) dstNode = srcNode;

--- a/src/main/java/fr/inria/prophet4j/utility/Structure.java
+++ b/src/main/java/fr/inria/prophet4j/utility/Structure.java
@@ -324,6 +324,8 @@ public interface Structure {
         DeleteType,
         InsertType,
         UpdateType,
+        //Delete and Move
+        PartialDeleteType,
     }
 
     enum RepairKind { // implementation is at RepairGenerator.java
@@ -341,10 +343,11 @@ public interface Structure {
         // REPLACE_STMT_RF
         ReplaceKind,            // genReplaceStmt()
         ReplaceStringKind,      // genReplaceStmt()
-        // REMOVE_STMT_RF
-        RemoveGuardKind,
-        // REMOVE_GUARD_RF
-        RemoveSTMTKind
+        //code deletion related features
+        RemovePartialIFKind,
+        RemoveSTMTKind,
+        RemoveWholeIFKind,
+        RemoveWholeBlockKind,
     }
 
     class DiffEntry { // DiffResultEntry

--- a/src/main/java/fr/inria/prophet4j/utility/Structure.java
+++ b/src/main/java/fr/inria/prophet4j/utility/Structure.java
@@ -341,6 +341,10 @@ public interface Structure {
         // REPLACE_STMT_RF
         ReplaceKind,            // genReplaceStmt()
         ReplaceStringKind,      // genReplaceStmt()
+        // REMOVE_STMT_RF
+        RemoveGuardKind,
+        // REMOVE_GUARD_RF
+        RemoveSTMTKind
     }
 
     class DiffEntry { // DiffResultEntry

--- a/src/test/java/fr/inria/prophet4j/OriginalFeatureExtractorTest.java
+++ b/src/test/java/fr/inria/prophet4j/OriginalFeatureExtractorTest.java
@@ -262,6 +262,16 @@ public class OriginalFeatureExtractorTest {
                     str1 = "class Foo{public void bar(){\nboolean a=false;\n}}";
                     assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
                     break;
+                case REMOVE_GUARD_RF:
+                    str0 = "class Foo{public void bar(){\nboolean a=true;\nif(a&&true){}\n}}";
+                    str1 = "class Foo{public void bar(){\nboolean a=true;\n}}";
+                    assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
+                    break;
+                case REMOVE_STMT_RF:
+                    str0 = "class Foo{public void bar(){\nboolean a=true;\nboolean b=true;\n}}";
+                    str1 = "class Foo{public void bar(){\nboolean a=true;\n}}";
+                    assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
+                    break;
             }
         }
         if (caseFeature instanceof ValueFeature) {

--- a/src/test/java/fr/inria/prophet4j/OriginalFeatureExtractorTest.java
+++ b/src/test/java/fr/inria/prophet4j/OriginalFeatureExtractorTest.java
@@ -261,17 +261,39 @@ public class OriginalFeatureExtractorTest {
                     str0 = "class Foo{public void bar(){\nboolean a=true;\n}}";
                     str1 = "class Foo{public void bar(){\nboolean a=false;\n}}";
                     assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
-                    break;
-                case REMOVE_GUARD_RF:
-                    str0 = "class Foo{public void bar(){\nboolean a=true;\nif(a&&true){}\n}}";
+                    break;              
+                case REMOVE_WHOLE_IF:
+                    str0 = "class Foo{public void bar(){\nboolean a=true;\nif(a){\n int b=1;\n}\n}}";
                     str1 = "class Foo{public void bar(){\nboolean a=true;\n}}";
                     assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
                     break;
-                case REMOVE_STMT_RF:
+                case REMOVE_PARTIAL_IF:
+                		//only remove the if condition and keep the statements in the condition
+                    str0 = "class Foo{public void bar(){\nboolean a=true;\nif(a){\nint b=1;\n}\n}}";
+                    str1 = "class Foo{public void bar(){\nboolean a=true;\nint b=1;\n}}";
+                    assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
+                    //remove the if condition and part of statements inside it and keep some statements in the condition
+                    str0 = "class Foo{public void bar(){\nboolean a=true;\nif(a){\nint b=1;\nint c=0;\n}\n}}";
+                    str1 = "class Foo{public void bar(){\nboolean a=true;\nint b=1;\n}}";
+                    assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
+                    break;               
+                case REMOVE_STMT:
+                		//remove a statement
                     str0 = "class Foo{public void bar(){\nboolean a=true;\nboolean b=true;\n}}";
                     str1 = "class Foo{public void bar(){\nboolean a=true;\n}}";
                     assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
-                    break;
+                    //remove a statement from else block
+                    str0 = "class Foo{public void bar(){\nboolean a=true;\nif(a){\nint b=1;\n}\nelse{int b=2;\nint c=3;\n}\n}}";
+	            		str1 = "class Foo{public void bar(){\nboolean a=true;\nif(a){\nint b=1;\n}\nelse{int b=2;\n}\n}}";
+	                assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
+	                break;                   
+                case REMOVE_WHOLE_BLOCK:
+                		//remove the whole else block
+                		str0 = "class Foo{public void bar(){\nboolean a=true;\nif(a){\nint b=1;\n}\nelse{int b=2;}\n}}";
+                		str1 = "class Foo{public void bar(){\nboolean a=true;\nif(a){\nint b=1;\n}\n}}";
+                    assertEquals(Boolean.TRUE, check(str0, str1, checkFeature));
+                    break;     
+               
             }
         }
         if (caseFeature instanceof ValueFeature) {


### PR DESCRIPTION
Hi @martinezmatias,

In this PR, I propose two code removal related features: Remove_Guard and Remove_Statement.
Previous, the code deletion was considered Insert_Guard.  The two new test cases are also added to this PR.