### PR TITLE
added try catch block to avoid crash in repairnator

### DIFF
--- a/src/main/java/fr/inria/coming/codefeatures/RepairnatorFeatures.java
+++ b/src/main/java/fr/inria/coming/codefeatures/RepairnatorFeatures.java
@@ -41,13 +41,29 @@ public class RepairnatorFeatures {
 
 	public ODSLabel getLabel(File pairFolder) throws Exception {
 
+		try {		
+		//if the pairFolder not exist
+		if (!pairFolder.exists()) {
+			log.error("The pairFolder file " + pairFolder.getPath() + " not exist!");
+			return ODSLabel.UNKNOWN;
+		}
+
+		
 		// Obtain feature in libsvm format
 		String features = extractFeatures(pairFolder);
 		if ("".equals(features)) {
 			return ODSLabel.UNKNOWN;
 		}
 		// Load test data in libsvm format
-		File tempFile = File.createTempFile("test", ".txt");
+		
+		File tempFile = null;
+		try {
+			tempFile = File.createTempFile("test", ".txt");
+		} catch (Exception e) {
+			log.error("ODS cannot create a feature file test.txt in the disk ");
+			return ODSLabel.UNKNOWN;
+		}
+		
 		try (FileWriter sb = new FileWriter(tempFile)) {
 			sb.append(features);
 		}
@@ -71,6 +87,9 @@ public class RepairnatorFeatures {
 			return ODSLabel.OVERFITTING;
 		} else {
 			return ODSLabel.CORRECT;
+		}
+		} catch (Exception e) {
+			return ODSLabel.UNKNOWN;
 		}
 
 	}

--- a/src/test/java/fr/inria/coming/spoon/features/RepairnatorFeatureTest.java
+++ b/src/test/java/fr/inria/coming/spoon/features/RepairnatorFeatureTest.java
@@ -38,4 +38,11 @@ public class RepairnatorFeatureTest {
 		ODSLabel label = new RepairnatorFeatures().getLabel(pairFolder);
 		assertEquals(label, ODSLabel.CORRECT);
 	}
+	
+	@Test
+	public void invalidFilePath() throws Exception {
+		File pairFolder = new File("invalid/path");
+		ODSLabel label = new RepairnatorFeatures().getLabel(pairFolder);
+		assertEquals(label, ODSLabel.UNKNOWN);
+	}
 }


### PR DESCRIPTION
In this PR, we improved the robust of ODS code for repairnator to avoid crashing.