### PR TITLE
Upgrade guava to 30.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>27.1-jre</version>
+			<version>30.1-jre</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Upgrades guava to latest version to fix a compatibility issue with the same dependency in `docker-client` that is being used in https://github.com/eclipse/repairnator. 

More info, see https://github.com/eclipse/repairnator/pull/1153#issuecomment-797119557