### PR TITLE
Update nexus-staging-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.2</version>
+						<version>1.6.13</version>
 						<extensions>true</extensions>
 						<configuration>
 							<serverId>ossrh</serverId>


### PR DESCRIPTION
Update the nexus-staging-maven-plugin version to fix the issue with reflective access in Java 17. 