### PR TITLE
Fix issue #259

### DIFF
--- a/src/main/java/fr/inria/coming/codefeatures/codeanalyze/LogicalExpressionAnalyzer.java
+++ b/src/main/java/fr/inria/coming/codefeatures/codeanalyze/LogicalExpressionAnalyzer.java
@@ -681,7 +681,7 @@ public class LogicalExpressionAnalyzer extends AbstractCodeAnalyzer {
 
 				for (CtInvocation invocation : invocationssInStatement) {
 					
-					if(!invocation.getTarget().toString().isEmpty()) {
+					if(invocation.getTarget() != null && !invocation.getTarget().toString().isEmpty()) {
 						continue;
 					}
 


### PR DESCRIPTION
Handle null value of spoon.reflect.code.CtInvocation.getTarget() when Spoon fails to parse input accurately.